### PR TITLE
Revert "converted prop types to safer React.ComponentPropsWithRef, op…

### DIFF
--- a/libs/formbuilder/src/lib/components/fieldbuilder/fieldbuilder.component.tsx
+++ b/libs/formbuilder/src/lib/components/fieldbuilder/fieldbuilder.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, FC } from 'react';
+import React, { useState, Fragment, FunctionComponent } from 'react';
 import { FieldTypePicker, FieldType } from '../fieldtype/fieldtype.component';
 import { FieldInfo } from '../fieldinfo/fieldinfo.component';
 import { FieldConfig, GenericFieldConfig } from '../fieldconfig/fieldconfig.component';
@@ -14,17 +14,17 @@ enum Tab {
 
 const buildTabLink = (tab: Tab, currentTab: Tab, setCurrentTab: (React.Dispatch<React.SetStateAction<Tab>>), disabled=false) => {
     if (tab == currentTab){
-        return disabled ?
+        return disabled ? 
             <a className="nav-link disabled" aria-disabled="true" aria-current="page" onClick={(event) => {setCurrentTab(tab)}}>{tab}</a> :
             <a className="nav-link active" aria-current="page" onClick={(event) => {setCurrentTab(tab)}}>{tab}</a>
     } else {
-        return disabled ?
+        return disabled ? 
             <a className="nav-link disabled" aria-disabled="true" onClick={(event) => {setCurrentTab(tab)}}>{tab}</a> :
             <a className="nav-link" onClick={(event) => {setCurrentTab(tab)}}>{tab}</a>
     }
 }
 
-export const FieldBuilder: FC<FieldBuilderProps> = (props) => {
+export const FieldBuilder: FunctionComponent<FieldBuilderProps> = (props) => {
     const [currentTab, setCurrentTab] = useState<Tab>(Tab.info)
     const [fieldType, setFieldType] = useState<FieldType | undefined>()
     const [name, setName] = useState("")
@@ -36,7 +36,7 @@ export const FieldBuilder: FC<FieldBuilderProps> = (props) => {
         tempFieldConfig[key] = value
         setFieldConfig(tempFieldConfig)
     }
-
+    
     return (
         <Fragment>
             <div className={'container'}>
@@ -54,7 +54,7 @@ export const FieldBuilder: FC<FieldBuilderProps> = (props) => {
                                 }
                             </li>
                             {
-                                fieldType === undefined ?
+                                fieldType === undefined ? 
                                 <li className="nav-item">
                                     {
                                         buildTabLink(Tab.config, currentTab, setCurrentTab, true)
@@ -66,7 +66,7 @@ export const FieldBuilder: FC<FieldBuilderProps> = (props) => {
                                     }
                                 </li>
                             }
-
+                            
                         </ul>
                         <br/>
                         {
@@ -83,7 +83,7 @@ export const FieldBuilder: FC<FieldBuilderProps> = (props) => {
                                         case "description":
                                             setDescription(event.target["value"])
                                             break;
-
+                                    
                                         default:
                                             break;
                                     }
@@ -92,7 +92,7 @@ export const FieldBuilder: FC<FieldBuilderProps> = (props) => {
                                 <FieldInfo name={name} description={description} />
                             </form>
                         }
-                        {
+                        {   
                             currentTab == Tab.type &&
                             <form onChange={
                                 (event) => {

--- a/libs/formbuilder/src/lib/components/fieldconfig/fieldconfig.component.tsx
+++ b/libs/formbuilder/src/lib/components/fieldconfig/fieldconfig.component.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, FC } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import {
     FormLabel,
     FormCheck,
@@ -11,7 +11,7 @@ import { FieldType } from '../fieldtype/fieldtype.component';
 type FieldConfigProps = {
     fieldType: FieldType
     fieldProps: GenericFieldConfig
-}
+}   
 
 interface DateConfig {
     mindate: string,
@@ -32,7 +32,7 @@ const renderDateConfig = (props: DateConfig) => {
         <FormLabel>Placeholder:</FormLabel>
         <FormInput name="placeholder" value={props.placeholder} />
         {
-            props.required === true ?
+            props.required === true ? 
             <FormCheck>
                 <FormCheckLabel>Required</FormCheckLabel>
                 <FormCheckInput name="required" checked={true} />
@@ -42,7 +42,7 @@ const renderDateConfig = (props: DateConfig) => {
                 <FormCheckInput name="required" />
             </FormCheck>
         }
-
+        
     </Fragment>
 }
 
@@ -66,7 +66,7 @@ const renderTextConfig = (props: TextConfig) => {
             <FormLabel>Placeholder:</FormLabel>
             <FormInput name="placeholder" value={props.placeholder} />
             {
-                props.required === true ?
+                props.required === true ? 
                 <FormCheck>
                     <FormCheckLabel>Required</FormCheckLabel>
                     <FormCheckInput name="required" checked={true} />
@@ -103,7 +103,7 @@ const renderIntegerConfig = (props: IntegerConfig) => {
             <FormLabel>Placeholder:</FormLabel>
             <FormInput name="placeholder" value={props.placeholder} />
             {
-                props.required === true ?
+                props.required === true ? 
                 <FormCheck>
                     <FormCheckLabel>Required</FormCheckLabel>
                     <FormCheckInput name="required" checked={true} />
@@ -149,7 +149,7 @@ const renderDropdownConfig = (props: DropdownConfig) => {
             <FormLabel>Placeholder:</FormLabel>
             <FormInput name="placeholder" value={props.placeholder} />
             {
-                props.required === true ?
+                props.required === true ? 
                 <FormCheck>
                     <FormCheckLabel>Required</FormCheckLabel>
                     <FormCheckInput name="required" checked={true} />
@@ -181,7 +181,7 @@ const renderConfig = (fieldType: FieldType, fieldProps: GenericFieldConfig) => {
             return renderDropdownConfig(fieldProps as DropdownConfig)
         case FieldType.multidropdown:
             return renderMultiDropdownConfig(fieldProps as DropdownConfig)
-
+    
         default:
             return (
                 <p>No render function found</p>
@@ -191,7 +191,7 @@ const renderConfig = (fieldType: FieldType, fieldProps: GenericFieldConfig) => {
 
 export type GenericFieldConfig = DateConfig | TextConfig | IntegerConfig | CheckboxConfig | DropdownConfig
 
-export const FieldConfig: FC<FieldConfigProps> = (props) => {
+export const FieldConfig: FunctionComponent<FieldConfigProps> = (props) => {
     return (
         <Fragment>
             {

--- a/libs/formbuilder/src/lib/components/fieldinfo/fieldinfo.component.tsx
+++ b/libs/formbuilder/src/lib/components/fieldinfo/fieldinfo.component.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, FC } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import {
     FormLabel,
     FormInput
@@ -9,7 +9,7 @@ type FieldInfoProps = {
     description: string;
 }
 
-export const FieldInfo: FC<FieldInfoProps> = (props) => {
+export const FieldInfo: FunctionComponent<FieldInfoProps> = (props) => {
     return (
         <Fragment>
             <FormLabel>Name:</FormLabel>

--- a/libs/formbuilder/src/lib/components/fieldtype/fieldtype.component.tsx
+++ b/libs/formbuilder/src/lib/components/fieldtype/fieldtype.component.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, FC } from 'react';
+import React, { Fragment, FunctionComponent } from 'react';
 import {
     FormLabel,
     FormCheck,
@@ -42,7 +42,7 @@ const makeFieldTypeRadios = (selected: FieldType | undefined) => {
     return returnList
 }
 
-export const FieldTypePicker: FC<FieldTypeProps> = (props) => {
+export const FieldTypePicker: FunctionComponent<FieldTypeProps> = (props) => {
     return (
         <Fragment>
             {

--- a/libs/shared/ui-toolkit/src/lib/components/button/button.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/button/button.component.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import React, { ButtonHTMLAttributes, FunctionComponent } from 'react';
 import classNames from 'classnames';
 
-type ButtonProps = React.ComponentPropsWithRef<'button'> & {
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   kind?:
     | 'primary'
     | 'secondary'
@@ -16,7 +16,7 @@ type ButtonProps = React.ComponentPropsWithRef<'button'> & {
   outline?: boolean;
 };
 
-export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
+export const Button: FunctionComponent<ButtonProps> = (props: ButtonProps) => {
   const { kind, size, outline, className, children, ...otherProps } = props;
   const classes: string[] = [];
   classes.push('btn');
@@ -34,12 +34,12 @@ export const Button: React.FC<ButtonProps> = (props: ButtonProps) => {
   );
 };
 
-type CloseButtonProps = ButtonProps & {
+type CloseButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   size?: 'sm' | 'lg';
 };
 
 export const CloseButton = (() => {
-  const cmp: React.FC<CloseButtonProps> = ({
+  const cmp: FunctionComponent<CloseButtonProps> = ({
     size,
     className,
     children,
@@ -52,7 +52,7 @@ export const CloseButton = (() => {
       'btn-lg': size === 'lg',
     });
     return (
-      <button {...props} className={className} {...props}>
+      <button className={className} {...props}>
         {children}
       </button>
     );

--- a/libs/shared/ui-toolkit/src/lib/components/button/button.stories.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/button/button.stories.tsx
@@ -16,7 +16,7 @@ storiesOf('Buttons', module).add('default', () => (
         <Button kind="info">Info</Button>
         <Button kind="dark">Dark</Button>
         <Button kind="light">Light</Button>
-        <Button kind="link" type="submit">Link</Button>
+        <Button kind="link">Link</Button>
       </CardBody>
     </Card>
     <Card>

--- a/libs/shared/ui-toolkit/src/lib/components/card/card.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/card/card.component.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { AnchorHTMLAttributes, FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-type CardProps = React.ComponentPropsWithRef<'div'>;
+type CardProps = HTMLAttributes<HTMLDivElement>;
 
-export const Card: React.FC<CardProps> = (props) => {
+export const Card: FunctionComponent<CardProps> = (props) => {
   const className = classNames('card', props.className);
   return (
     <div {...props} className={className}>
@@ -12,9 +12,9 @@ export const Card: React.FC<CardProps> = (props) => {
   );
 };
 
-type CardBodyProps = React.ComponentPropsWithRef<'div'>;
+type CardBodyProps = HTMLAttributes<HTMLDivElement>;
 
-export const CardBody: React.FC<CardBodyProps> = (props) => {
+export const CardBody: FunctionComponent<CardBodyProps> = (props) => {
   return (
     <div {...props} className={classNames(props.className, 'card-body')}>
       {props.children}
@@ -22,9 +22,9 @@ export const CardBody: React.FC<CardBodyProps> = (props) => {
   );
 };
 
-type CardTextProps = React.ComponentPropsWithRef<'p'>;
+type CardTextProps = HTMLAttributes<HTMLParagraphElement>;
 
-export const CardText: React.FC<CardTextProps> = (props) => {
+export const CardText: FunctionComponent<CardTextProps> = (props) => {
   return (
     <p {...props} className={classNames(props.className, 'card-text')}>
       {props.children}
@@ -32,9 +32,9 @@ export const CardText: React.FC<CardTextProps> = (props) => {
   );
 };
 
-type CardTitleProps = React.ComponentPropsWithRef<'h5'>;
+type CardTitleProps = HTMLAttributes<HTMLHeadingElement>;
 
-export const CardTitle: React.FC<CardTitleProps> = (props) => {
+export const CardTitle: FunctionComponent<CardTitleProps> = (props) => {
   return (
     <h5 {...props} className={classNames(props.className, 'card-title')}>
       {props.children}
@@ -42,9 +42,9 @@ export const CardTitle: React.FC<CardTitleProps> = (props) => {
   );
 };
 
-type CardSubTitleProps = React.ComponentPropsWithRef<'h6'>;
+type CardSubTitleProps = HTMLAttributes<HTMLHeadingElement>;
 
-export const CardSubTitle: React.FC<CardSubTitleProps> = (props) => {
+export const CardSubTitle: FunctionComponent<CardSubTitleProps> = (props) => {
   return (
     <h6
       {...props}
@@ -60,9 +60,9 @@ export const CardSubTitle: React.FC<CardSubTitleProps> = (props) => {
   );
 };
 
-type CardLinkProps = React.ComponentPropsWithRef<'a'>;
+type CardLinkProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 
-export const CardLink: React.FC<CardLinkProps> = (props) => {
+export const CardLink: FunctionComponent<CardLinkProps> = (props) => {
   return (
     <a {...props} className={classNames(props.className, 'card-link')}>
       {props.children}
@@ -70,9 +70,9 @@ export const CardLink: React.FC<CardLinkProps> = (props) => {
   );
 };
 
-type CardTopImageProps = React.ComponentPropsWithRef<'img'>;
+type CardTopImageProps = HTMLAttributes<HTMLImageElement>;
 
-export const CardTopImage: React.FC<CardTopImageProps> = (props) => {
+export const CardTopImage: FunctionComponent<CardTopImageProps> = (props) => {
   // 'alt' attribute would be in props
   // eslint-disable-next-line jsx-a11y/alt-text
   return (
@@ -82,9 +82,9 @@ export const CardTopImage: React.FC<CardTopImageProps> = (props) => {
   );
 };
 
-type CardHeaderProps = React.ComponentPropsWithRef<'div'>;
+type CardHeaderProps = HTMLAttributes<HTMLDivElement>;
 
-export const CardHeader: React.FC<CardHeaderProps> = (props) => {
+export const CardHeader: FunctionComponent<CardHeaderProps> = (props) => {
   return (
     <div {...props} className={classNames(props.className, 'card-header')}>
       {props.children}
@@ -92,9 +92,9 @@ export const CardHeader: React.FC<CardHeaderProps> = (props) => {
   );
 };
 
-type CardHeaderFeaturedProps = React.ComponentPropsWithRef<'h5'>;
+type CardHeaderFeaturedProps = HTMLAttributes<HTMLHeadingElement>;
 
-export const CardHeaderFeatured: React.FC<CardHeaderFeaturedProps> = (
+export const CardHeaderFeatured: FunctionComponent<CardHeaderFeaturedProps> = (
   props
 ) => {
   return (
@@ -104,9 +104,9 @@ export const CardHeaderFeatured: React.FC<CardHeaderFeaturedProps> = (
   );
 };
 
-type CardFooterProps = React.ComponentPropsWithRef<'div'>;
+type CardFooterProps = HTMLAttributes<HTMLDivElement>;
 
-export const CardFooter: React.FC<CardFooterProps> = (props) => {
+export const CardFooter: FunctionComponent<CardFooterProps> = (props) => {
   return (
     <div {...props} className={classNames(props.className, 'card-footer')}>
       {props.children}

--- a/libs/shared/ui-toolkit/src/lib/components/collapse/collapse.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/collapse/collapse.component.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import { FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-export type CollapseProps = React.ComponentPropsWithRef<'div'> & {
+export type CollapseProps = HTMLAttributes<HTMLDivElement> & {
   show?: boolean;
 };
 
-export const Collapse: React.FC<CollapseProps> = (props) => {
+export const Collapse: FunctionComponent<CollapseProps> = (props) => {
   const classes = classNames(props.className, 'collapse', {
     show: props.show,
   });

--- a/libs/shared/ui-toolkit/src/lib/components/form-input/form-input.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/form-input/form-input.component.tsx
@@ -1,4 +1,12 @@
-import * as React from 'react';
+import {
+  ChangeEvent,
+  CSSProperties,
+  FunctionComponent,
+  HTMLAttributes,
+  InputHTMLAttributes,
+  LabelHTMLAttributes,
+  useCallback,
+} from 'react';
 import { FormLabel, FormLabelProps } from '../form-label/label.component';
 import classNames from 'classnames';
 
@@ -9,7 +17,7 @@ export enum InputType {
   DateTime = 'datetimelocal',
 }
 
-export interface FormInputProps extends React.ComponentPropsWithRef<'input'> {
+export interface FormInputProps extends InputHTMLAttributes<HTMLInputElement> {
   plaintext?: boolean;
   colorInput?: boolean;
   onValueChanged?: (value: any) => void;
@@ -46,7 +54,7 @@ const transformInputValue = (props: FormInputProps, value: any) => {
   return value;
 };
 
-export const FormInput: React.FC<FormInputProps> = (props) => {
+export const FormInput: FunctionComponent<FormInputProps> = (props) => {
   const {
     plaintext,
     colorInput,
@@ -64,7 +72,7 @@ export const FormInput: React.FC<FormInputProps> = (props) => {
     }
   }
 
-  const handleOnChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+  const handleOnChange = (ev: ChangeEvent<HTMLInputElement>) => {
     const value = transformInputValue(props, ev?.target?.value);
     if (onValueChanged) {
       onValueChanged(value);
@@ -87,7 +95,7 @@ export interface Inliner {
   inline?: boolean;
 }
 
-export const FormCheck: React.FC<React.ComponentPropsWithRef<'div'> & Inliner> = ({ className, inline, ...props }) => {
+export const FormCheck: FunctionComponent<HTMLAttributes<HTMLDivElement> & Inliner> = ({ className, inline, ...props }) => {
   const classes = classNames(className, 'form-check', { inline: inline });
   return (
     <div className={classes} {...props}>
@@ -96,7 +104,7 @@ export const FormCheck: React.FC<React.ComponentPropsWithRef<'div'> & Inliner> =
   );
 };
 
-export const FormSwitch: React.FC<React.ComponentPropsWithRef<'div'>> = ({
+export const FormSwitch: FunctionComponent<HTMLAttributes<HTMLDivElement>> = ({
   className,
   ...props
 }) => {
@@ -110,7 +118,8 @@ export const FormSwitch: React.FC<React.ComponentPropsWithRef<'div'>> = ({
   );
 };
 
-export const FormCheckInput: React.FC<React.ComponentPropsWithRef<'input'>
+export const FormCheckInput: FunctionComponent<
+  InputHTMLAttributes<HTMLInputElement>
 > = (props) => {
   return (
     <input
@@ -121,7 +130,7 @@ export const FormCheckInput: React.FC<React.ComponentPropsWithRef<'input'>
   );
 };
 
-export const FormRadioInput: React.FC<React.ComponentPropsWithRef<'input'> & { checked?: boolean }> = (props) => {
+export const FormRadioInput: FunctionComponent<InputHTMLAttributes<HTMLInputElement> & { checked?: boolean }> = (props) => {
   return (
     <input
       {...props}
@@ -131,8 +140,8 @@ export const FormRadioInput: React.FC<React.ComponentPropsWithRef<'input'> & { c
   );
 };
 
-export const FormCheckLabel: React.FC<
-  React.ComponentPropsWithRef<'label'>
+export const FormCheckLabel: FunctionComponent<
+  LabelHTMLAttributes<HTMLLabelElement>
 > = (props) => {
   return (
     <label
@@ -143,9 +152,9 @@ export const FormCheckLabel: React.FC<
 };
 
 
-type ValidFeedbackProps = React.ComponentPropsWithRef<'div'> & { show: boolean };
+type ValidFeedbackProps = HTMLAttributes<HTMLDivElement> & { show: boolean };
 
-export const ValidFeedback: React.FC<ValidFeedbackProps> = ({
+export const ValidFeedback: FunctionComponent<ValidFeedbackProps> = ({
   className,
   children,
   show,
@@ -163,9 +172,9 @@ export const ValidFeedback: React.FC<ValidFeedbackProps> = ({
 };
 
 
-type InvalidFeedbackProps = React.ComponentPropsWithRef<'div'> & { show: boolean };
+type InvalidFeedbackProps = HTMLAttributes<HTMLDivElement> & { show: boolean };
 
-export const InvalidFeedback: React.FC<InvalidFeedbackProps> = (
+export const InvalidFeedback: FunctionComponent<InvalidFeedbackProps> = (
   { className, children, show, ...props },
   ref
 ) => {
@@ -182,9 +191,9 @@ export const InvalidFeedback: React.FC<InvalidFeedbackProps> = (
 };
 
 
-type FormHelpProps = React.ComponentPropsWithRef<'div'>;
+type FormHelpProps = HTMLAttributes<HTMLDivElement>;
 
-export const FormHelp: React.FC<FormHelpProps> = (
+export const FormHelp: FunctionComponent<FormHelpProps> = (
   { className, children, ...props },
   ref
 ) => {
@@ -199,15 +208,15 @@ type FormControlProps = {
   label?: string;
   description?: string;
   containerClassName?: string;
-  containerStyle?: React.CSSProperties;
-  containerProps?: React.ComponentPropsWithRef<'div'>;
+  containerStyle?: CSSProperties;
+  containerProps?: HTMLAttributes<HTMLDivElement>;
   labelProps?: FormLabelProps;
-  descriptionProps?: React.ComponentPropsWithRef<'div'>;
+  descriptionProps?: HTMLAttributes<HTMLDivElement>;
   validFeedback?: string;
   invalidFeedback?: string;
 } & FormInputProps;
 
-export const FormControl: React.FC<FormControlProps> = (
+export const FormControl: FunctionComponent<FormControlProps> = (
   {
     label,
     description,

--- a/libs/shared/ui-toolkit/src/lib/components/form-input/form-input.spec.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/form-input/form-input.spec.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { FC } from 'react';
+import { FunctionComponent } from 'react';
 import { FormInput, FormInputProps, FormLabel } from '@nrc.no/ui';
 import {
   useForm,
@@ -14,7 +14,7 @@ type ContextProps = {
   onInvalid: SubmitErrorHandler<any>;
 };
 
-const Context: FC<ContextProps> = ({
+const Context: FunctionComponent<ContextProps> = ({
   onValid,
   onInvalid,
   children,
@@ -43,7 +43,7 @@ type TestCaseProps = {
   testCase: TestCase;
 };
 
-const FormField: FC<TestCaseProps> = ({
+const FormField: FunctionComponent<TestCaseProps> = ({
   testCase,
   ...props
 }) => {

--- a/libs/shared/ui-toolkit/src/lib/components/form-label/label.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/form-label/label.component.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { FunctionComponent, LabelHTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-export type FormLabelProps = React.ComponentPropsWithRef<'label'>;
+export type FormLabelProps = LabelHTMLAttributes<HTMLLabelElement>;
 
-export const FormLabel: React.FC<FormLabelProps> = (props) => {
+export const FormLabel: FunctionComponent<FormLabelProps> = (props) => {
   const { className, ...otherProps } = props;
   return (
     <label {...otherProps} className={classNames(className, 'form-label')}>

--- a/libs/shared/ui-toolkit/src/lib/components/form-select/form-select.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/form-select/form-select.component.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react'
+import { FunctionComponent, SelectHTMLAttributes } from 'react';
 import classNames from 'classnames';
 
-type SelectProps = React.ComponentPropsWithRef<'select'>;
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 
-export const FormSelect: React.FC<SelectProps> = (props) => {
+export const FormSelect: FunctionComponent<SelectProps> = (props) => {
   return (
     <select {...props} className={classNames(props.className, 'form-select')} />
   );

--- a/libs/shared/ui-toolkit/src/lib/components/icons/icons.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/icons/icons.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import { FunctionComponent } from 'react';
 
-const bootstrapIcon: (className: string) => React.FC<React.ComponentPropsWithoutRef<'i'>> = className => {
-  return ({ children, ...props }) => {
-    return <i {...props} className={'bi bi-' + className}>{children}</i>;
+const bootstrapIcon: (className: string) => FunctionComponent = className => {
+  return props => {
+    return <i className={'bi bi-' + className}>{props.children}</i>;
   };
 };
 

--- a/libs/shared/ui-toolkit/src/lib/components/list-group/list-group.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/list-group/list-group.component.tsx
@@ -1,4 +1,4 @@
-import { AnchorHTMLAttributes, FC, HTMLAttributes } from 'react';
+import { AnchorHTMLAttributes, FunctionComponent, HTMLAttributes } from 'react';
 import classNames from 'classnames';
 export interface ListGroupProps
   extends HTMLAttributes<HTMLDivElement | HTMLUListElement> {
@@ -7,7 +7,7 @@ export interface ListGroupProps
   numbered?: boolean;
 }
 
-const ListGroup: FC<ListGroupProps> = ({
+const ListGroup: FunctionComponent<ListGroupProps> = ({
   flush,
   isActionListGroup,
   numbered,
@@ -47,7 +47,7 @@ export interface ListGroupItemProps {
   isAction?: boolean;
 }
 
-const ListGroupItem: FC<
+const ListGroupItem: FunctionComponent<
   (HTMLAttributes<HTMLLIElement> | AnchorHTMLAttributes<HTMLAnchorElement>) &
     ListGroupItemProps
 > = ({ active, isAction, disabled, ...props }) => {

--- a/libs/shared/ui-toolkit/src/lib/components/modal/modal.stories.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/modal/modal.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import { Fragment, PropsWithChildren, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { Modal, ModalBody, ModalContent, ModalDialog, ModalFooter, ModalHeader, ModalTitle } from './modal';
 import { Button } from '../button/button.component';
@@ -22,9 +22,9 @@ type StoryProps = {
   storyName: string
 } & ModalProps
 
-const ModalStory = (props: React.PropsWithChildren<StoryProps>) => {
+const ModalStory = (props: PropsWithChildren<StoryProps>) => {
   const { storyName, children, ...otherProps } = props;
-  const [show, setShow] = React.useState(false);
+  const [show, setShow] = useState(false);
   return (
 
     <div className={"mb-2 border p-3"}>
@@ -44,7 +44,7 @@ const ModalStory = (props: React.PropsWithChildren<StoryProps>) => {
 storiesOf('Modal', module)
   .add('default', () => {
     return (
-      <>
+      <Fragment>
         <ModalStory storyName={'Default'}>
           <p>Just a basic, default modal</p>
         </ModalStory>
@@ -66,6 +66,6 @@ storiesOf('Modal', module)
         <ModalStory storyName={'Small'} size={'sm'}>
           <p>A small modal</p>
         </ModalStory>
-      </>
+      </Fragment>
     );
   });

--- a/libs/shared/ui-toolkit/src/lib/components/modal/modal.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/modal/modal.tsx
@@ -1,4 +1,12 @@
-import * as React from 'react';
+import {
+  createContext,
+  FunctionComponent,
+  HTMLAttributes,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import BaseModal, { ModalProps as BaseModalProps } from 'react-overlays/Modal';
 import useCallbackRef from '@restart/hooks/useCallbackRef';
@@ -14,10 +22,9 @@ interface ModalContextProps {
   onHide: () => void;
 }
 
-const ModalContext = React.createContext<ModalContextProps>({
+const ModalContext = createContext<ModalContextProps>({
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  onHide: () => {
-  }
+  onHide: () => {},
 });
 
 type ModalProps = {
@@ -32,53 +39,53 @@ type ModalProps = {
   fullscreenBelow?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 } & BaseModalProps;
 
-export const Modal: React.FC<ModalProps> = ({
-                                              style,
-                                              size,
-                                              fullscreen,
-                                              fullscreenBelow,
+export const Modal: FunctionComponent<ModalProps> = ({
+  style,
+  size,
+  fullscreen,
+  fullscreenBelow,
 
-                                              fade,
-                                              scrollable,
-                                              verticallyCentered,
-                                              className,
-                                              children,
+  fade,
+  scrollable,
+  verticallyCentered,
+  className,
+  children,
 
-                                              /* BaseModal props*/
-                                              show,
-                                              animation,
-                                              backdrop,
-                                              keyboard,
-                                              onEscapeKeyDown,
-                                              onShow,
-                                              onHide,
-                                              container,
-                                              autoFocus,
-                                              enforceFocus,
-                                              restoreFocus,
-                                              restoreFocusOptions,
-                                              onEntered,
-                                              onExit,
-                                              onExiting,
-                                              onEnter,
-                                              onEntering,
-                                              onExited,
-                                              backdropClassName,
+  /* BaseModal props*/
+  show,
+  animation,
+  backdrop,
+  keyboard,
+  onEscapeKeyDown,
+  onShow,
+  onHide,
+  container,
+  autoFocus,
+  enforceFocus,
+  restoreFocus,
+  restoreFocusOptions,
+  onEntered,
+  onExit,
+  onExiting,
+  onEnter,
+  onEntering,
+  onExited,
+  backdropClassName,
 
-                                              ...props
-                                            }) => {
+  ...props
+}) => {
   // We use a react context to wrap the Modal.
 
-  const [modalStyle, setStyle] = React.useState({});
-  const [animateStaticModal, setAnimateStaticModal] = React.useState(false);
-  const waitingForMouseUpRef = React.useRef(false);
-  const ignoreBackdropClickRef = React.useRef(false);
-  const removeStaticModalAnimationRef = React.useRef<(() => void) | null>(null);
+  const [modalStyle, setStyle] = useState({});
+  const [animateStaticModal, setAnimateStaticModal] = useState(false);
+  const waitingForMouseUpRef = useRef(false);
+  const ignoreBackdropClickRef = useRef(false);
+  const removeStaticModalAnimationRef = useRef<(() => void) | null>(null);
 
   const [modal, setModalRef] = useCallbackRef<{ dialog: any }>();
   const handleHide = useEventCallback(onHide);
 
-  const modalContext = React.useMemo(() => ({ onHide: handleHide }), [handleHide]);
+  const modalContext = useMemo(() => ({ onHide: handleHide }), [handleHide]);
 
   function getModalManager() {
     return new ModalManager();
@@ -103,7 +110,7 @@ export const Modal: React.FC<ModalProps> = ({
       paddingLeft:
         !containerIsOverflowing && modalIsOverflowing
           ? getScrollbarSize()
-          : undefined
+          : undefined,
     });
   }
 
@@ -215,7 +222,7 @@ export const Modal: React.FC<ModalProps> = ({
     className = classNames(className, 'modal-dialog-centered');
   }
 
-  const renderBackdrop = React.useCallback(
+  const renderBackdrop = useCallback(
     (backdropProps) => {
       return (
         <div
@@ -240,7 +247,7 @@ export const Modal: React.FC<ModalProps> = ({
   const renderDialog = (dialogProps) => {
     return (
       <div
-        role='dialog'
+        role="dialog"
         {...dialogProps}
         style={baseModalStyle}
         className={classNames(className, 'modal')}
@@ -302,17 +309,17 @@ Modal.defaultProps = {
   autoFocus: true,
   enforceFocus: true,
   restoreFocus: true,
-  animation: false
+  animation: false,
 };
 
-type ModalDialogProps = React.ComponentPropsWithRef<'div'> & {
+type ModalDialogProps = HTMLAttributes<HTMLDivElement> & {
   size?: 'lg' | 'sm' | 'xl';
 };
 
-export const ModalDialog: React.FC<ModalDialogProps> = ({
-                                                          size,
-                                                          ...props
-                                                        }) => {
+export const ModalDialog: FunctionComponent<ModalDialogProps> = ({
+  size,
+  ...props
+}) => {
   return (
     <div
       {...props}
@@ -327,7 +334,7 @@ export const ModalDialog: React.FC<ModalDialogProps> = ({
   );
 };
 
-export const ModalContent: React.FC<React.ComponentPropsWithRef<'div'>> = (
+export const ModalContent: FunctionComponent<HTMLAttributes<HTMLDivElement>> = (
   props
 ) => {
   return (
@@ -337,7 +344,7 @@ export const ModalContent: React.FC<React.ComponentPropsWithRef<'div'>> = (
   );
 };
 
-export const ModalHeader: React.FC<React.ComponentPropsWithRef<'div'>> = (
+export const ModalHeader: FunctionComponent<HTMLAttributes<HTMLDivElement>> = (
   props
 ) => {
   return (
@@ -347,7 +354,7 @@ export const ModalHeader: React.FC<React.ComponentPropsWithRef<'div'>> = (
   );
 };
 
-export const ModalTitle: React.FC<React.ComponentPropsWithRef<'div'>> = (
+export const ModalTitle: FunctionComponent<HTMLAttributes<HTMLDivElement>> = (
   props
 ) => {
   return (
@@ -357,7 +364,7 @@ export const ModalTitle: React.FC<React.ComponentPropsWithRef<'div'>> = (
   );
 };
 
-export const ModalBody: React.FC<React.ComponentPropsWithRef<'div'>> = (
+export const ModalBody: FunctionComponent<HTMLAttributes<HTMLDivElement>> = (
   props
 ) => {
   return (
@@ -366,7 +373,7 @@ export const ModalBody: React.FC<React.ComponentPropsWithRef<'div'>> = (
     </h5>
   );
 };
-export const ModalFooter: React.FC<React.ComponentPropsWithRef<'div'>> = (
+export const ModalFooter: FunctionComponent<HTMLAttributes<HTMLDivElement>> = (
   props
 ) => {
   return (

--- a/libs/shared/ui-toolkit/src/lib/components/progress-bar/progress-bar.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/progress-bar/progress-bar.component.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { FunctionComponent, HTMLAttributes } from 'react';
 
-type ProgessBarProps =  React.ComponentPropsWithRef<'div'> & {
+type ProgessBarProps = {
   labels : string[],
   progress : number
-};
+} &  HTMLAttributes<HTMLDivElement>;
 
 const renderProgressColumn = (i:number, numberOfColumns: number) => {
   if (i === 0 || i === numberOfColumns -1 ){
@@ -20,7 +20,7 @@ const renderTextColumn = (i : number, labels: string[]) => {
   }
 }
 
-export const ProgressBar: React.FC<ProgessBarProps> = ({labels, progress, ...props}) => {
+export const ProgressBar: FunctionComponent<ProgessBarProps> = ({labels, progress, ...props}) => {
 
   const numberOfColumns = (labels.length * 2) + (labels.length - 1)
   const progressColumns = []
@@ -43,3 +43,25 @@ export const ProgressBar: React.FC<ProgessBarProps> = ({labels, progress, ...pro
       </tr>
   </table>;
 };
+
+//
+//  +-----+-flex-grow:1-+-----+------------------+   ---------+
+//XX|  |--|-------------|--|--|---------------|  |            |
+//  |TEXT1|             |TEXT2|             TEXT3|            |
+//  +-----+-------------+-----+------------------+   ---------+
+//
+// n-1 "bars"
+
+// FLEX ROW
+// <div class="minigrid">
+//   <div class="progress-row">
+//     <div class="border-bottom" style="margin-top:0.5rem"></div>
+//     <div>TICKER</div>
+//     <div class="border-bottom"  style="margin-top:0.5rem"></div>
+//   <div>
+//   <div class="text-row">
+//     <div>TEXT</div>
+//   </div>
+// </div> 
+// 
+//

--- a/libs/shared/ui-toolkit/src/lib/components/select/select.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/select/select.component.tsx
@@ -1,25 +1,32 @@
-import * as  React from 'react';
-import Select, { components, ControlProps, MultiValueProps, OptionProps, Props } from 'react-select';
+import React, { FunctionComponent } from 'react';
+import Select, {
+  components,
+  ControlProps,
+  MultiValueProps,
+  OptionProps,
+  Props
+} from 'react-select';
 import classNames from 'classnames';
-import { XIcon } from '@nrc.no/ui-toolkit';
+import { CloseButton, XIcon } from '@nrc.no/ui-toolkit';
+import StateManager from 'react-select';
 
 // a thin wrapper over react-select applying our own bootstrap styles
 
 
-const MultiValue: React.FC<MultiValueProps<any>> = (props) => {
-  const classes = classNames('bg-primary text-light', props.className, {});
+const MultiValue: FunctionComponent<MultiValueProps<any>> = (props) => {
+  const classes = classNames('bg-primary text-light', props.className, {})
   return (
     <components.MultiValue {...props} className={classes}>
-      {props.children}
+        {props.children}
     </components.MultiValue>
-  );
-};
+  )
+}
 
-const MultiValueLabel: React.FC<MultiValueProps<any>> = ({
-                                                           children,
-                                                           innerProps,
-                                                           ...props
-                                                         }) => {
+const MultiValueLabel: FunctionComponent<MultiValueProps<any>> = ({
+  children,
+  innerProps,
+  ...props
+}) => {
   const classes = classNames('bg-primary', props.className, {});
   return (
     <components.MultiValueLabel {...innerProps} className={classes}>
@@ -28,19 +35,19 @@ const MultiValueLabel: React.FC<MultiValueProps<any>> = ({
   );
 };
 
-const MultiValueRemove: React.FC<MultiValueProps<any>> = ({
-                                                            innerProps,
-                                                            ...props
-                                                          }) => {
+const MultiValueRemove: FunctionComponent<MultiValueProps<any>> = ({
+  innerProps,
+  ...props
+}) => {
   const classes = classNames(props.className, '', {});
   return (
     <components.MultiValueRemove {...innerProps}>
       <XIcon />
     </components.MultiValueRemove>
-  );
-};
+  )
+}
 
-const Control: React.FC<ControlProps<any, any>> = ({ children, ...props }) => {
+const Control: FunctionComponent<ControlProps<any, any>> = ({ children, ...props }) => {
   const classes = classNames('dropdown', props.className, {});
   return (
     <components.Control {...props} className={classes}>
@@ -49,14 +56,14 @@ const Control: React.FC<ControlProps<any, any>> = ({ children, ...props }) => {
   );
 };
 
-const Option: React.FC<OptionProps<any, any>> = ({
-                                                   innerRef,
-                                                   innerProps,
-                                                   ...props
-                                                 }) => {
+const Option: FunctionComponent<OptionProps<any, any>> = ({
+  innerRef,
+  innerProps,
+  ...props
+}) => {
   const classes = classNames('list-group-item', props.className, {
     disabled: props.isDisabled,
-    active: props.isSelected
+    active: props.isSelected,
   });
   return (
     <div ref={innerRef} {...innerProps} className={classes}>
@@ -67,9 +74,9 @@ const Option: React.FC<OptionProps<any, any>> = ({
 
 type SelectProps = Props
 
-const CustomSelect: React.FC<SelectProps> = (props) => {
-  return <Select {...props} components={{ Control, Option, MultiValue, MultiValueLabel, MultiValueRemove }} />;
-};
+const CustomSelect: FunctionComponent<SelectProps> = (props) => {
+  return <Select {...props} components={{ Control, Option, MultiValue, MultiValueLabel, MultiValueRemove }} />
+}
 
-export { Control, Option, MultiValue, MultiValueLabel, MultiValueRemove };
-export default CustomSelect;
+export { Control, Option, MultiValue, MultiValueLabel, MultiValueRemove, }
+export default CustomSelect

--- a/libs/shared/ui-toolkit/src/lib/components/tab/tabs.component.tsx
+++ b/libs/shared/ui-toolkit/src/lib/components/tab/tabs.component.tsx
@@ -1,41 +1,42 @@
-import * as React from 'react';
+import { FunctionComponent, useState } from 'react';
 import classNames from 'classnames';
+import * as React from 'react';
 
-export type TabProps = React.ComponentPropsWithRef<'a'> & {
+type TabProps = any & {
   key: number;
-  onPointerDown: (e: React.PointerEvent<HTMLAnchorElement>) => void;
+  onPointerDown: (e: PointerEvent) => unknown;
   isActive?: boolean;
   isDisabled?: boolean;
 }
 
-const Tab: React.FC<TabProps> = (props) => {
+const Tab: FunctionComponent<TabProps> = (props) => {
   const classes = classNames('nav-item', props.className, {
     active: props.isActive,
     disabled: props.isDisabled
-  });
-  return (<a className={classes} href={props.href} onPointerDown={props.onPointerDown}>{props.children}</a>);
-};
+  })
+  return (<a className={classes} href={props.href} onPointerDown={props.onPointerDown}>{props.children}</a>)
+}
 
-export type TabsProps = {
-} // TODO
+type TabsProps = HTMLUListElement & {
 
-const Tabs: React.FC<> = ({ children, ...props }) => {
-  const [activeTab, setActiveTab] = React.useState(0);
+}
+
+const Tabs: FunctionComponent<TabsProps> = ({children, ...props}) => {
+  const [activeTab, setActiveTab] = useState(0)
 
   const handlePointerDown = (key: number) => setActiveTab(key);
 
-  const classes = classNames('nav nav-tabs', props.className, {});
+  const classes = classNames('nav nav-tabs', props.className, {})
   return (
     <nav className={classes}>
       {
-        React.Children.map(children, (child, index) => {
-          React.cloneElement(child);
-        })
-      }
-      {/*<Tab key={index} onPointerDown={() => handlePointerDown(index)} isActive={activeTab === index} isDisabled={child.props.isDisabled}>child</Tab>*/}
+        React.Children.map(children, (child, index) =>
+          React.cloneElement(child, )
+     }
+     {/*<Tab key={index} onPointerDown={() => handlePointerDown(index)} isActive={activeTab === index} isDisabled={child.props.isDisabled}>child</Tab>*/}
     </nav>
-  );
-};
+  )
+}
 
 
-export { Tab, Tabs };
+export { Tab, Tabs }


### PR DESCRIPTION
switched up the component props strategy based on advice for building a react component librairy found here: https://react-typescript-cheatsheet.netlify.app/docs/advanced/intro

Also switched from `import [module], { ...module } from 'react'` to `import * as React from 'react`
