### PR TITLE
bugfix: case view restricts parties options based on party type

### DIFF
--- a/api2/pkg/parties/parties/client.go
+++ b/api2/pkg/parties/parties/client.go
@@ -19,11 +19,21 @@ func NewClient(basePath string) *Client {
 	}
 }
 
+type ListOptions struct {
+	PartyType string `json:"partyTypeId" bson:"partyTypeId"`
+}
+
 func (c *Client) List(ctx context.Context, listOptions ListOptions) (*PartyList, error) {
 	req, err := http.NewRequest("GET", c.basePath+"/apis/v1/parties", nil)
 	if err != nil {
 		return nil, err
 	}
+	//req = req.WithContext(ctx)
+	qry := req.URL.Query()
+	if len(listOptions.PartyType) > 0 {
+		qry.Set("partyTypeId", listOptions.PartyType)
+	}
+	req.URL.RawQuery = qry.Encode()
 	req.Header.Set("Accept", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/api2/pkg/parties/parties/client.go
+++ b/api2/pkg/parties/parties/client.go
@@ -20,7 +20,7 @@ func NewClient(basePath string) *Client {
 }
 
 type ListOptions struct {
-	PartyType string `json:"partyTypeId" bson:"partyTypeId"`
+	PartyTypeID string `json:"partyTypeId" bson:"partyTypeId"`
 }
 
 func (c *Client) List(ctx context.Context, listOptions ListOptions) (*PartyList, error) {
@@ -28,10 +28,10 @@ func (c *Client) List(ctx context.Context, listOptions ListOptions) (*PartyList,
 	if err != nil {
 		return nil, err
 	}
-	//req = req.WithContext(ctx)
+	req = req.WithContext(ctx)
 	qry := req.URL.Query()
-	if len(listOptions.PartyType) > 0 {
-		qry.Set("partyTypeId", listOptions.PartyType)
+	if len(listOptions.PartyTypeID) > 0 {
+		qry.Set("partyTypeId", listOptions.PartyTypeID)
 	}
 	req.URL.RawQuery = qry.Encode()
 	req.Header.Set("Accept", "application/json")

--- a/api2/pkg/parties/parties/rest.go
+++ b/api2/pkg/parties/parties/rest.go
@@ -48,7 +48,7 @@ func (h *Handler) List(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 	listOptions := &ListOptions{
-		PartyType: req.URL.Query().Get("partyTypeId"),
+		PartyTypeID: req.URL.Query().Get("partyTypeId"),
 	}
 
 	ret, err := h.store.List(ctx, *listOptions)

--- a/api2/pkg/parties/parties/rest.go
+++ b/api2/pkg/parties/parties/rest.go
@@ -44,13 +44,12 @@ func (h *Handler) Get(w http.ResponseWriter, req *http.Request) {
 
 }
 
-type ListOptions struct {
-	PartyType string
-}
-
 func (h *Handler) List(w http.ResponseWriter, req *http.Request) {
+
 	ctx := req.Context()
-	listOptions := &ListOptions{}
+	listOptions := &ListOptions{
+		PartyType: req.URL.Query().Get("partyTypeId"),
+	}
 
 	ret, err := h.store.List(ctx, *listOptions)
 	if err != nil {

--- a/api2/pkg/parties/parties/store.go
+++ b/api2/pkg/parties/parties/store.go
@@ -33,8 +33,8 @@ func (s *Store) Get(ctx context.Context, id string) (*Party, error) {
 func (s *Store) List(ctx context.Context, listOptions ListOptions) (*PartyList, error) {
 	filter := bson.M{}
 
-	if len(listOptions.PartyType) > 0 {
-		filter["partyTypes"] = listOptions.PartyType
+	if len(listOptions.PartyTypeID) > 0 {
+		filter["partyTypes"] = listOptions.PartyTypeID
 	}
 
 	res, err := s.collection.Find(ctx, filter)

--- a/api2/pkg/webapp/cases.go
+++ b/api2/pkg/webapp/cases.go
@@ -134,8 +134,7 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 
 	qry := req.URL.Query()
 	caseTypeId := qry.Get("caseTypeId")
-	var partyTypeId string
-	partyTypeId = ""
+	partyTypeId := ""
 	for _, caseType := range caseTypes.Items {
 		if caseType.ID == caseTypeId {
 			partyTypeId = caseType.PartyTypeID
@@ -143,7 +142,7 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 	}
 
 	listOptions := parties.ListOptions{
-		PartyType: partyTypeId,
+		PartyTypeID: partyTypeId,
 	}
 
 	p, err := partiesClient.List(waitCtx, listOptions)

--- a/api2/pkg/webapp/cases.go
+++ b/api2/pkg/webapp/cases.go
@@ -133,7 +133,7 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 	}
 
 	qry := req.URL.Query()
-	caseTypeID := qry.Get("caseTypeID")
+	caseTypeID := qry.Get("caseTypeId")
 	partyTypeID := ""
 	for _, caseType := range caseTypes.Items {
 		if caseType.ID == caseTypeID {
@@ -152,7 +152,7 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 
 	if err := h.template.ExecuteTemplate(w, "casenew", map[string]interface{}{
 		"PartyID":    qry.Get("partyId"),
-		"CaseTypeID": qry.Get("caseTypeID"),
+		"CaseTypeID": qry.Get("caseTypeId"),
 		"CaseTypes":  caseTypes,
 		"Parties":    p,
 	}); err != nil {

--- a/api2/pkg/webapp/cases.go
+++ b/api2/pkg/webapp/cases.go
@@ -133,16 +133,16 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 	}
 
 	qry := req.URL.Query()
-	caseTypeId := qry.Get("caseTypeId")
-	partyTypeId := ""
+	caseTypeID := qry.Get("caseTypeID")
+	partyTypeID := ""
 	for _, caseType := range caseTypes.Items {
-		if caseType.ID == caseTypeId {
-			partyTypeId = caseType.PartyTypeID
+		if caseType.ID == caseTypeID {
+			partyTypeID = caseType.PartyTypeID
 		}
 	}
 
 	listOptions := parties.ListOptions{
-		PartyTypeID: partyTypeId,
+		PartyTypeID: partyTypeID,
 	}
 
 	p, err := partiesClient.List(waitCtx, listOptions)
@@ -152,7 +152,7 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 
 	if err := h.template.ExecuteTemplate(w, "casenew", map[string]interface{}{
 		"PartyID":    qry.Get("partyId"),
-		"CaseTypeID": qry.Get("caseTypeId"),
+		"CaseTypeID": qry.Get("caseTypeID"),
 		"CaseTypes":  caseTypes,
 		"Parties":    p,
 	}); err != nil {

--- a/api2/pkg/webapp/cases.go
+++ b/api2/pkg/webapp/cases.go
@@ -127,19 +127,29 @@ func (h *Handler) NewCase(w http.ResponseWriter, req *http.Request) {
 		return err
 	})
 
-	listOptions := &parties.ListOptions{} // TODO
-	g.Go(func() error {
-		var err error
-		p, err = partiesClient.List(waitCtx, *listOptions)
-		return err
-	})
-
 	if err := g.Wait(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	qry := req.URL.Query()
+	caseTypeId := qry.Get("caseTypeId")
+	var partyTypeId string
+	partyTypeId = ""
+	for _, caseType := range caseTypes.Items {
+		if caseType.ID == caseTypeId {
+			partyTypeId = caseType.PartyTypeID
+		}
+	}
+
+	listOptions := parties.ListOptions{
+		PartyType: partyTypeId,
+	}
+
+	p, err := partiesClient.List(waitCtx, listOptions)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 
 	if err := h.template.ExecuteTemplate(w, "casenew", map[string]interface{}{
 		"PartyID":    qry.Get("partyId"),

--- a/api2/pkg/webapp/templates/casenew.gohtml
+++ b/api2/pkg/webapp/templates/casenew.gohtml
@@ -31,7 +31,7 @@
                     </div>
                     <div class="form-floating mb-3">
                         <select id="party" class="form-select" name="partyId">
-                            {{if and .Parties}}
+                            {{if .Parties}}
                                 <option {{if not $.PartyID}}selected{{end}}></option>
                                 {{range .Parties.Items}}
                                     <option {{if eq .ID $.PartyID}}selected{{end}} value="{{.ID}}">{{.}}</option>
@@ -60,7 +60,9 @@
         const caseTypeSelect = document.querySelector("#case-type");
         caseTypeSelect.onchange = (event) => {
             const caseTypeId = event.target.value;
-            if (caseTypeId === "") return;
+            if (caseTypeId === "") {
+                return;
+            }
             window.location.href = `/cases/new?caseTypeId=${caseTypeId}`
         }
     </script>

--- a/api2/pkg/webapp/templates/casenew.gohtml
+++ b/api2/pkg/webapp/templates/casenew.gohtml
@@ -31,7 +31,7 @@
                     </div>
                     <div class="form-floating mb-3">
                         <select id="party" class="form-select" name="partyId">
-                            {{if .Parties}}
+                            {{if and .Parties}}
                                 <option {{if not $.PartyID}}selected{{end}}></option>
                                 {{range .Parties.Items}}
                                     <option {{if eq .ID $.PartyID}}selected{{end}} value="{{.ID}}">{{.}}</option>
@@ -56,6 +56,14 @@
             </div>
         </div>
     </div>
+    <script>
+        const caseTypeSelect = document.querySelector("#case-type");
+        caseTypeSelect.onchange = (event) => {
+            const caseTypeId = event.target.value;
+            if (caseTypeId === "") return;
+            window.location.href = `/cases/new?caseTypeId=${caseTypeId}`
+        }
+    </script>
     </body>
     </html>
 {{end}}


### PR DESCRIPTION
Should work. But SSR forces page refresh on case type choice. Maybe a better solution would filter the parties client-side?