### PR TITLE
COR-13: modify individual List to only include individuals and not all parties

### DIFF
--- a/api2/pkg/individuals/store.go
+++ b/api2/pkg/individuals/store.go
@@ -58,12 +58,32 @@ func (s *Store) Get(ctx context.Context, ID string) (*Individual, error) {
 
 func (s *Store) List(ctx context.Context, listOptions ListOptions) (*IndividualList, error) {
 
-	filter := bson.M{}
+	filter := bson.M{
+		"partyTypeIds": bson.M{
+			"$elemMatch": bson.M{
+				"$eq": partytypes.IndividualPartyType.ID,
+			},
+		},
+	}
 
 	if len(listOptions.PartyTypeIDs) > 0 {
-		filter["partyTypeIds"] = bson.M{
-			"$all": listOptions.PartyTypeIDs,
+		filter = bson.M{
+			"$and": bson.A{
+				bson.M{
+					"partyTypeIds": bson.M{
+						"$all": listOptions.PartyTypeIDs,
+					},
+				},
+				bson.M{
+					"partyTypeIds": bson.M{
+						"$elemMatch": bson.M{
+							"$eq": partytypes.IndividualPartyType.ID,
+						},
+					},
+				},
+			},
 		}
+
 	}
 
 	cursor, err := s.collection.Find(ctx, filter)


### PR DESCRIPTION
- New default behaviour of List is to filter on partyTypeIds looking for individuals
- If ListOptions is passed in, the behaviour is to `and` the list options filter with the individual partyTypeIds filter