### PR TITLE
COR-15: only show relevant attributes

### DIFF
--- a/api2/pkg/parties/attributes/client.go
+++ b/api2/pkg/parties/attributes/client.go
@@ -20,13 +20,23 @@ func NewClient(basePath string) *Client {
 	}
 }
 
-func (c *Client) List(ctx context.Context) (*AttributeList, error) {
+type ListOptions struct {
+	PartyTypeIDs []string
+}
+
+func (c *Client) List(ctx context.Context, listOptions ListOptions) (*AttributeList, error) {
 	req, err := http.NewRequest("GET", c.basePath+"/apis/v1/attributes", nil)
 	if err != nil {
 		return nil, err
 	}
 	req = req.WithContext(ctx)
 	auth.SetAuthorizationHeader(ctx, req)
+	qry := req.URL.Query()
+	if len(listOptions.PartyTypeIDs) > 0 {
+		for _, partyTypeID := range listOptions.PartyTypeIDs {
+			qry.Add("partyTypeIds", partyTypeID)
+		}
+	}
 	req.Header.Set("Accept", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/api2/pkg/parties/attributes/rest.go
+++ b/api2/pkg/parties/attributes/rest.go
@@ -23,7 +23,11 @@ func (h *Handler) List(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 
-	list, err := h.store.List(ctx)
+	listOptions := ListOptions{
+		PartyTypeIDs: req.URL.Query()["partyTypeIds"],
+	}
+
+	list, err := h.store.List(ctx, listOptions)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/api2/pkg/parties/attributes/store.go
+++ b/api2/pkg/parties/attributes/store.go
@@ -16,9 +16,17 @@ func NewStore(mongoClient *mongo.Client, database string) *Store {
 	}
 }
 
-func (s *Store) List(ctx context.Context) (*AttributeList, error) {
+func (s *Store) List(ctx context.Context, listOptions ListOptions) (*AttributeList, error) {
 
-	cursor, err := s.collection.Find(ctx, bson.M{})
+	filter := bson.M{}
+
+	if len(listOptions.PartyTypeIDs) > 0 {
+		filter["partyTypeIds"] = bson.M{
+			"$all": listOptions.PartyTypeIDs,
+		}
+	}
+
+	cursor, err := s.collection.Find(ctx, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/api2/pkg/testing/attribute_test.go
+++ b/api2/pkg/testing/attribute_test.go
@@ -76,7 +76,7 @@ func (s *Suite) TestAttributesCRUD() {
 	assert.Equal(s.T(), updated, get)
 
 	// LIST
-	list, err := s.server.AttributeClient.List(s.ctx)
+	list, err := s.server.AttributeClient.List(s.ctx, attributes.ListOptions{})
 	assert.NoError(s.T(), err)
 	assert.Contains(s.T(), list.Items, get)
 

--- a/api2/pkg/webapp/individuals.go
+++ b/api2/pkg/webapp/individuals.go
@@ -23,7 +23,7 @@ func (h *Handler) Individuals(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	attributesClient := attributes.NewClient("http://localhost:9000")
-	attrs, err := attributesClient.List(ctx)
+	attrs, err := attributesClient.List(ctx, attributes.ListOptions{})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -113,7 +113,9 @@ func (h *Handler) Individual(w http.ResponseWriter, req *http.Request) {
 
 	g.Go(func() error {
 		var err error
-		attrs, err = h.attributeClient.List(waitCtx)
+		attrs, err = h.attributeClient.List(waitCtx, attributes.ListOptions{
+			PartyTypeIDs: []string{partytypes.IndividualPartyType.ID},
+		})
 		return err
 	})
 

--- a/api2/pkg/webapp/settings.go
+++ b/api2/pkg/webapp/settings.go
@@ -28,7 +28,7 @@ func (h *Handler) Attributes(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	list, err := h.attributeClient.List(ctx)
+	list, err := h.attributeClient.List(ctx, attributes.ListOptions{})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/api2/pkg/webapp/settings.go
+++ b/api2/pkg/webapp/settings.go
@@ -34,8 +34,7 @@ func (h *Handler) Attributes(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	partyTypesCli := partytypes.NewClient("http://localhost:9000")
-	partyTypes, err := partyTypesCli.List(ctx)
+	partyTypes, err := h.partyTypeClient.List(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -51,7 +50,13 @@ func (h *Handler) Attributes(w http.ResponseWriter, req *http.Request) {
 }
 
 func (h *Handler) NewAttribute(w http.ResponseWriter, req *http.Request) {
-	if err := h.renderFactory.New(req).ExecuteTemplate(w, "attribute", map[string]interface{}{}); err != nil {
+	if err := h.renderFactory.New(req).ExecuteTemplate(w, "attribute", map[string]interface{}{
+		"PartyTypes": partytypes.PartyTypeList{
+			Items: []*partytypes.PartyType{
+				&partytypes.IndividualPartyType,
+			},
+		},
+	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -80,6 +85,11 @@ func (h *Handler) Attribute(w http.ResponseWriter, req *http.Request) {
 
 	if err := h.renderFactory.New(req).ExecuteTemplate(w, "attribute", map[string]interface{}{
 		"Attribute": a,
+		"PartyTypes": partytypes.PartyTypeList{
+			Items: []*partytypes.PartyType{
+				&partytypes.IndividualPartyType,
+			},
+		},
 	}); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -147,7 +157,7 @@ func (h *Handler) PostAttribute(ctx context.Context, attribute *attributes.Attri
 
 	attribute.Name = values.Get("name")
 	attribute.ValueType = expressions.ValueType{}
-	attribute.PartyTypeIDs = values["subjectType"]
+	attribute.PartyTypeIDs = values["partyTypes"]
 	attribute.Translations = translations
 	attribute.IsPersonallyIdentifiableInfo = values.Get("isPersonallyIdentifiableInfo") == "true"
 

--- a/api2/pkg/webapp/templates/attribute.gohtml
+++ b/api2/pkg/webapp/templates/attribute.gohtml
@@ -45,7 +45,9 @@
                                 <select id="subject-type-input"
                                         name="partyTypes"
                                         class="form-select">
-                                    <option>Individual</option>
+                                    {{range .PartyTypes.Items}}
+                                    <option value="{{.ID}}">{{.Name}}</option>
+                                    {{end}}
                                 </select>
                                 <label for="subject-type-input">Subject Type</label>
                             </div>
@@ -118,7 +120,9 @@
                 ]
             },
             partyTypes: [
-                {value: "individual", name: "Individual"}
+                {{range .PartyTypes.Items}}
+                {value: "{{.ID}}", name: "{{.Name}}"}
+                {{end}}
             ]
         })
         {{else }}
@@ -126,12 +130,14 @@
             attribute: {
                 name: "",
                 valueType: "",
-                partyTypes: "individual",
+                partyTypes: ["{{(index .PartyTypes.Items 0).ID}}"],
                 isPersonallyIdentifiableInformation: false,
                 translations: []
             },
             partyTypes: [
-                {value: "individual", name: "Individual"}
+                {{range .PartyTypes.Items}}
+                {value: "{{.ID}}", name: "{{.Name}}"}
+                {{end}}
             ]
         })
         {{end}}

--- a/api2/pkg/webapp/templates/attribute.gohtml
+++ b/api2/pkg/webapp/templates/attribute.gohtml
@@ -136,7 +136,7 @@
             },
             partyTypes: [
                 {{range .PartyTypes.Items}}
-                {value: "{{.ID}}", name: "{{.Name}}"}
+                {value: "{{.ID}}", name: "{{.Name}}"},
                 {{end}}
             ]
         })

--- a/api2/pkg/webapp/templates/attributes.gohtml
+++ b/api2/pkg/webapp/templates/attributes.gohtml
@@ -27,8 +27,8 @@
                         <a class="card mb-3 shadow-sm text-dark text-decoration-none attribute"
                            href="/settings/attributes/{{.ID}}">
                             <div class="card-body">
-                                {{ range .PartyTypes}}
-                                    {{$partyType := $.PartyTypes.GetByID .}}
+                                {{ range .PartyTypeIDs}}
+                                    {{$partyType := $.PartyTypeIDs.GetByID .}}
                                     <small class="d-block text-muted">{{$partyType.Name}}</small>
                                 {{end}}
                                 {{.Name}}


### PR DESCRIPTION
- On attribute API, move from static subject type to using party type
- Use hardcoded static individual type in the subject type dropdown on the attribute definition page
- Filter the list of attributes in the backend to retrieve only those who apply to a beneficiary 