### PR TITLE
COR-46-fix-personal-info-not-saving

### DIFF
--- a/api2/pkg/parties/attributes/store.go
+++ b/api2/pkg/parties/attributes/store.go
@@ -78,11 +78,11 @@ func (s *Store) Update(ctx context.Context, attribute *Attribute) error {
 		"id": attribute.ID,
 	}, bson.M{
 		"$set": bson.M{
-			"name":                         attribute.Name,
-			"translations":                 attribute.Translations,
-			"valueType":                    attribute.ValueType,
-			"isPersonallyIdentifiableInfo": attribute.IsPersonallyIdentifiableInfo,
-			"partyTypeIds":                 attribute.PartyTypeIDs,
+			"name":         attribute.Name,
+			"translations": attribute.Translations,
+			"valueType":    attribute.ValueType,
+			"isPii":        attribute.IsPersonallyIdentifiableInfo,
+			"partyTypeIds": attribute.PartyTypeIDs,
 		},
 	})
 	if err != nil {

--- a/api2/pkg/webapp/settings.go
+++ b/api2/pkg/webapp/settings.go
@@ -159,7 +159,7 @@ func (h *Handler) PostAttribute(ctx context.Context, attribute *attributes.Attri
 	attribute.ValueType = expressions.ValueType{}
 	attribute.PartyTypeIDs = values["partyTypes"]
 	attribute.Translations = translations
-	attribute.IsPersonallyIdentifiableInfo = values.Get("isPersonallyIdentifiableInfo") == "true"
+	attribute.IsPersonallyIdentifiableInfo = values.Get("isPii") == "on"
 
 	var out *attributes.Attribute
 

--- a/api2/pkg/webapp/templates/attribute.gohtml
+++ b/api2/pkg/webapp/templates/attribute.gohtml
@@ -61,10 +61,11 @@
                             <!-- Personally Identifiable Info -->
                             <div class="form-check form-switch mb-3">
                                 <input id="is-pii-input"
-                                       name="isPersonallyIdentifiableInformation"
+                                       name="isPii"
                                        type="checkbox"
                                        class="form-check-input"
                                        data-cy="personal-info-chkbx"
+                                       {{if .Attribute.IsPersonallyIdentifiableInfo}}checked{{end}}
                                 >
                                 <label class="form-check-label" for="is-pii-input">
                                     Is Personally Identifiable Information
@@ -116,7 +117,7 @@
                 name: "{{.Attribute.Name}}",
                 valueType: "{{.Attribute.ValueType}}",
                 partyTypeIds: "{{.Attribute.PartyTypeIDs}}",
-                isPersonallyIdentifiableInformation: {{.Attribute.IsPersonallyIdentifiableInfo}},
+                isPii: {{.Attribute.IsPersonallyIdentifiableInfo}},
                 translations: [
                     {{range .Attribute.Translations}}
                     {
@@ -139,7 +140,7 @@
                 name: "",
                 valueType: "",
                 partyTypes: ["{{(index .PartyTypes.Items 0).ID}}"],
-                isPersonallyIdentifiableInformation: false,
+                isPii: false,
                 translations: []
             },
             partyTypes: [
@@ -155,7 +156,7 @@
         let name$ = attribute$.pipe(map(a => a.name))
         let valueType$ = attribute$.pipe(map(a => a.valueType))
         let partyTypes = attribute$.pipe(map(a => a.partyTypes))
-        let isPii$ = attribute$.pipe(map(a => a.isPersonallyIdentifiableInformation))
+        let isPii$ = attribute$.pipe(map(a => a.isPii))
         let translations$ = attribute$.pipe(map(a => a.translations))
         let availableLanguages$ = translations$.pipe(
             map(translations => {


### PR DESCRIPTION
fixed; also renamed html 'name' attribute to isPii to conform with json/bson nomenclature defined in the attribute api