### PR TITLE
Cor 60 notifications

### DIFF
--- a/api/.run/start.run.xml
+++ b/api/.run/start.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="start" type="GoApplicationRunConfiguration" factoryName="Go Application">
     <module name="core" />
-    <working_directory value="$PROJECT_DIR$/../api" />
+    <working_directory value="$PROJECT_DIR$/api" />
     <parameters value="--mongo-database=core --mongo-username=root --mongo-password=example" />
     <EXTENSION ID="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/api/pkg/apps/webapp/individuals.go
+++ b/api/pkg/apps/webapp/individuals.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/nrc-no/core/pkg/apps/cms"
 	"github.com/nrc-no/core/pkg/apps/iam"
+	"github.com/nrc-no/core/pkg/sessionmanager"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/sync/errgroup"
 	"net/http"
@@ -370,15 +371,24 @@ func (h *Server) PostIndividual(
 		var err error
 		individual, err = iamClient.Individuals().Create(ctx, b)
 		if err != nil {
+
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		h.sessionManager.AddNotification(ctx, &sessionmanager.Notification{
+			Message: fmt.Sprintf("%s successfully created", b.String()),
+			Theme:   "success",
+		})
 	} else {
 		var err error
 		if individual, err = iamClient.Individuals().Update(ctx, b); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		h.sessionManager.AddNotification(ctx, &sessionmanager.Notification{
+			Message: fmt.Sprintf("%s successfully updated", b.String()),
+			Theme:   "success",
+		})
 	}
 
 	// Update, create or delete the relationships

--- a/api/pkg/apps/webapp/renderer.go
+++ b/api/pkg/apps/webapp/renderer.go
@@ -12,6 +12,7 @@ import (
 type RenderInterface interface {
 	IsLoggedIn() bool
 	Profile() *Claims
+	Notifications() []*sessionmanager.Notification
 }
 
 // RendererFactory is a factory to create Renderer
@@ -32,6 +33,10 @@ func (r *RendererFactory) IsLoggedIn() bool {
 
 func (r *RendererFactory) Profile() *Claims {
 	return nil
+}
+
+func (r *RendererFactory) Notifications() []*sessionmanager.Notification {
+	return []*sessionmanager.Notification{}
 }
 
 // NewRendererFactory creates a new instance of the RendererFactory
@@ -92,10 +97,15 @@ func (r *Renderer) Profile() *Claims {
 	return profile
 }
 
+func (r *Renderer) Notifications() []*sessionmanager.Notification {
+	return r.sessionManager.ConsumeNotifications(r.req.Context())
+}
+
 // WithRenderInterface adds the RenderInterface methods to the template
 func WithRenderInterface(t *template.Template, intf RenderInterface) *template.Template {
 	return t.Funcs(map[string]interface{}{
-		"IsLoggedIn": intf.IsLoggedIn,
-		"Profile":    intf.Profile,
+		"IsLoggedIn":    intf.IsLoggedIn,
+		"Profile":       intf.Profile,
+		"Notifications": intf.Notifications,
 	})
 }

--- a/api/pkg/apps/webapp/templates/individual.gohtml
+++ b/api/pkg/apps/webapp/templates/individual.gohtml
@@ -6,6 +6,8 @@
 
     {{template "navbar"}}
 
+    {{template "notifications"}}
+
     {{template "individuals_nav" . }}
 
     <div class="container">

--- a/api/pkg/apps/webapp/templates/notifications.gohtml
+++ b/api/pkg/apps/webapp/templates/notifications.gohtml
@@ -1,0 +1,11 @@
+{{define "notifications"}}
+    {{$notifications := Notifications}}
+    {{if $notifications}}
+        {{range $index, $notification := $notifications}}
+            <div class="alert {{if $notification.Theme}}alert-{{$notification.Theme}}{{end}} alert-dismissible fade show" role="alert">
+                {{$notification.Message}}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {{end}}
+    {{end}}
+{{end}}

--- a/api/pkg/sessionmanager/interface.go
+++ b/api/pkg/sessionmanager/interface.go
@@ -57,6 +57,9 @@ func New(pool *redis.Pool, options Options) Store {
 	}
 }
 
+// Notification contains "flash" messages shown to the user.
+// The theme field should correspond to one of the bootstrap theme colors; eg. "success", "warning",
+// "danger", etc. https://getbootstrap.com/docs/5.0/customize/color/
 type Notification struct {
 	Message string
 	Theme   string
@@ -71,5 +74,9 @@ func (r RedisSessionManager) AddNotification(ctx context.Context, notification *
 	r.Put(ctx, "notifications", notifs)
 }
 func (r RedisSessionManager) ConsumeNotifications(ctx context.Context) []*Notification {
-	panic("implement me")
+	notifs, ok := r.Pop(ctx, "notifications").([]*Notification)
+	if !ok {
+		notifs = []*Notification{}
+	}
+	return notifs
 }


### PR DESCRIPTION
Basic notifications ("flashes") are now possible on any page by
1. Adding a call to `server.sessionManager.AddNotification(ctx, notification)` in the rendering file (eg. `webapp/individuals.go`)
2. Adding a reference to `{{template "notifications}}` in a page

This PR implements notifications on Individual creation/updates