### PR TITLE
COR-14: add way to represent party as a string for display purposes

### DIFF
--- a/api/pkg/apps/iam/types.go
+++ b/api/pkg/apps/iam/types.go
@@ -107,6 +107,30 @@ func (p *Party) AddPartyType(partyType string) {
 }
 
 func (p *Party) String() string {
+
+	// Staff
+	if p.HasPartyType(StaffPartyType.ID) {
+		return p.Attributes.Get(FirstNameAttribute.ID) +
+			" " +
+			p.Attributes.Get(LastNameAttribute.ID) +
+			" (" +
+			p.Attributes.Get(EMailAttribute.ID) +
+			")"
+	}
+
+	// Individual
+	if p.HasPartyType(IndividualPartyType.ID) {
+		return p.Attributes.Get(FirstNameAttribute.ID) +
+			" " +
+			p.Attributes.Get(LastNameAttribute.ID)
+	}
+
+	// Team
+	if p.HasPartyType(TeamPartyType.ID) {
+		return p.Attributes.Get(TeamNameAttribute.ID)
+	}
+
+	// Default
 	return p.ID
 }
 


### PR DESCRIPTION
As per @ludydoo 's guidance, I have altered the way the party .String function behaves

Now the IDs are replaced with a human readable string as can be seen on this case:
<img width="421" alt="Screenshot 2021-06-30 at 01 33 16" src="https://user-images.githubusercontent.com/15915453/123880531-27e09d00-d943-11eb-8a28-1068664668aa.png">
