### PR TITLE
COR-116 Test untested backend api (iam)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.DS_Store
 api/certs/cert.pem
 api/certs/key.pem
+*/coverage.out

--- a/.idea/core.iml
+++ b/.idea/core.iml
@@ -1,8 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
+  <component name="Go">
+    <buildTags>
+      <option name="customFlags">
+        <array>
+          <option value="integration" />
+        </array>
+      </option>
+    </buildTags>
+  </component>
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/api/third-party" />
+      <excludeFolder url="file://$MODULE_DIR$/api/certs" />
+      <excludeFolder url="file://$MODULE_DIR$/e2e/cypress/screenshots" />
+      <excludeFolder url="file://$MODULE_DIR$/e2e/cypress/videos" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/runConfigurations/iam_coverage_report.xml
+++ b/.idea/runConfigurations/iam_coverage_report.xml
@@ -1,0 +1,17 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iam coverage report" type="ShConfigurationType">
+    <option name="SCRIPT_TEXT" value="" />
+    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
+    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/api/pkg/apps/iam/test-coverage-report.sh" />
+    <option name="SCRIPT_OPTIONS" value="" />
+    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
+    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$/api/pkg/apps/iam" />
+    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
+    <option name="INTERPRETER_PATH" value="/usr/bin/bash" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="EXECUTE_IN_TERMINAL" value="true" />
+    <option name="EXECUTE_SCRIPT_FILE" value="true" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/start.xml
+++ b/.idea/runConfigurations/start.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="start" type="GoApplicationRunConfiguration" factoryName="Go Application">
+  <configuration default="false" name="start" type="GoApplicationRunConfiguration" factoryName="Go Application" activateToolWindowBeforeRun="false">
     <module name="core" />
     <working_directory value="$PROJECT_DIR$/api" />
     <parameters value="--mongo-database=core --mongo-username=root --mongo-password=example --mongo-hosts=localhost:27017 --environment=Development --fresh=true --seed=true --hydra-admin-url=https://localhost:4445 --hydra-public-url=https://localhost:4444 --login-templates-directory=pkg/apps/login/templates --login-client-id=login --login-client-name=login --login-client-secret=somesecret --login-iam-host=localhost:9000 --login-iam-scheme=https --web-templates-directory=pkg/apps/webapp/templates --web-client-id=webapp --web-client-secret=webapp --web-client-name=webapp --web-iam-host=localhost:9000 --web-iam-scheme=https --web-cms-host=localhost:9000 --web-cms-scheme=https --listen-address=:9000 --base-url=https://localhost:9000 --tls-cert-path=certs/cert.pem --tls-key-path=certs/key.pem" />

--- a/.idea/runConfigurations/test_iam.xml
+++ b/.idea/runConfigurations/test_iam.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test iam" type="GoTestRunConfiguration" factoryName="Go Test">
+    <module name="core" />
+    <working_directory value="$PROJECT_DIR$/api/pkg/apps/iam" />
+    <parameters value="--tags=integration" />
+    <root_directory value="$PROJECT_DIR$/api" />
+    <kind value="DIRECTORY" />
+    <package value="github.com/nrc-no/core/pkg/apps/iam" />
+    <directory value="$PROJECT_DIR$/api/pkg/apps/iam" />
+    <filePath value="$PROJECT_DIR$" />
+    <framework value="gotest" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/api/pkg/apps/iam/attribute_get.go
+++ b/api/pkg/apps/iam/attribute_get.go
@@ -4,21 +4,21 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetAttribute(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getAttribute(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	a, err := s.AttributeStore.Get(ctx, id)
+	a, err := s.attributeStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, a)
+	s.json(w, http.StatusOK, a)
 
 }

--- a/api/pkg/apps/iam/attribute_list.go
+++ b/api/pkg/apps/iam/attribute_list.go
@@ -4,21 +4,21 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListAttributes(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listAttributes(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 
 	listOptions := &AttributeListOptions{}
 	if err := listOptions.UnmarshalQueryParameters(req.URL.Query()); err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	list, err := s.AttributeStore.List(ctx, *listOptions)
+	list, err := s.attributeStore.list(ctx, *listOptions)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, list)
+	s.json(w, http.StatusOK, list)
 }

--- a/api/pkg/apps/iam/attribute_post.go
+++ b/api/pkg/apps/iam/attribute_post.go
@@ -5,22 +5,24 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostAttribute(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postAttributes(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 
 	var a Attribute
-	if err := s.Bind(req, &a); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &a); err != nil {
+		s.error(w, err)
 	}
 
-	a.ID = uuid.NewV4().String()
+	if a.ID == "" {
+		a.ID = uuid.NewV4().String()
+	}
 
-	if err := s.AttributeStore.Create(ctx, &a); err != nil {
-		s.Error(w, err)
+	if err := s.attributeStore.create(ctx, &a); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, a)
+	s.json(w, http.StatusOK, a)
 
 }

--- a/api/pkg/apps/iam/attribute_put.go
+++ b/api/pkg/apps/iam/attribute_put.go
@@ -4,24 +4,24 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutAttribute(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putAttribute(w http.ResponseWriter, req *http.Request) {
 
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
 	var payload Attribute
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	attribute, err := s.AttributeStore.Get(ctx, id)
+	attribute, err := s.attributeStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
@@ -30,11 +30,11 @@ func (s *Server) PutAttribute(w http.ResponseWriter, req *http.Request) {
 	attribute.PartyTypeIDs = payload.PartyTypeIDs
 	attribute.IsPersonallyIdentifiableInfo = payload.IsPersonallyIdentifiableInfo
 
-	if err := s.AttributeStore.Update(ctx, attribute); err != nil {
-		s.Error(w, err)
+	if err := s.attributeStore.update(ctx, attribute); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, payload)
+	s.json(w, http.StatusOK, payload)
 
 }

--- a/api/pkg/apps/iam/attribute_store.go
+++ b/api/pkg/apps/iam/attribute_store.go
@@ -11,7 +11,7 @@ type AttributeStore struct {
 	collection *mongo.Collection
 }
 
-func NewAttributeStore(ctx context.Context, mongoClient *mongo.Client, database string) (*AttributeStore, error) {
+func newAttributeStore(ctx context.Context, mongoClient *mongo.Client, database string) (*AttributeStore, error) {
 	store := &AttributeStore{
 		collection: mongoClient.Database(database).Collection("attributes"),
 	}
@@ -27,7 +27,9 @@ func NewAttributeStore(ctx context.Context, mongoClient *mongo.Client, database 
 	return store, nil
 }
 
-func (s *AttributeStore) List(ctx context.Context, listOptions AttributeListOptions) (*AttributeList, error) {
+// list returns an AttributeList. If AttributeListOptions are supplied, list returns a filtered list containing
+// only those items whose Attribute.PartyTypeIDs field contains all the elements given in the query.
+func (s *AttributeStore) list(ctx context.Context, listOptions AttributeListOptions) (*AttributeList, error) {
 
 	filter := bson.M{}
 
@@ -62,7 +64,7 @@ func (s *AttributeStore) List(ctx context.Context, listOptions AttributeListOpti
 
 }
 
-func (s *AttributeStore) Create(ctx context.Context, attribute *Attribute) error {
+func (s *AttributeStore) create(ctx context.Context, attribute *Attribute) error {
 	_, err := s.collection.InsertOne(ctx, attribute)
 	if err != nil {
 		return err
@@ -70,7 +72,7 @@ func (s *AttributeStore) Create(ctx context.Context, attribute *Attribute) error
 	return nil
 }
 
-func (s *AttributeStore) Get(ctx context.Context, id string) (*Attribute, error) {
+func (s *AttributeStore) get(ctx context.Context, id string) (*Attribute, error) {
 	result := s.collection.FindOne(ctx, bson.M{
 		"id": id,
 	})
@@ -84,7 +86,7 @@ func (s *AttributeStore) Get(ctx context.Context, id string) (*Attribute, error)
 	return &a, nil
 }
 
-func (s *AttributeStore) Update(ctx context.Context, attribute *Attribute) error {
+func (s *AttributeStore) update(ctx context.Context, attribute *Attribute) error {
 	_, err := s.collection.UpdateOne(ctx, bson.M{
 		"id": attribute.ID,
 	}, bson.M{

--- a/api/pkg/apps/iam/auth.go
+++ b/api/pkg/apps/iam/auth.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func (s *Server) WithAuth() func(handler http.Handler) http.Handler {
+func (s *Server) withAuth() func(handler http.Handler) http.Handler {
 
 	return func(handler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -17,22 +17,22 @@ func (s *Server) WithAuth() func(handler http.Handler) http.Handler {
 
 			token, err := auth.AuthHeaderTokenSource(req).GetToken()
 			if err != nil {
-				s.Error(w, err)
+				s.error(w, err)
 				return
 			}
 
-			res, err := s.HydraAdmin.IntrospectOAuth2Token(&admin.IntrospectOAuth2TokenParams{
+			res, err := s.hydraAdmin.IntrospectOAuth2Token(&admin.IntrospectOAuth2TokenParams{
 				Token:      token,
 				Context:    req.Context(),
-				HTTPClient: s.HydraHTTPClient,
+				HTTPClient: s.hydraHTTPClient,
 			})
 			if err != nil {
-				s.Error(w, err)
+				s.error(w, err)
 				return
 			}
 
 			if !*res.Payload.Active {
-				s.Error(w, err)
+				s.error(w, err)
 				return
 			}
 

--- a/api/pkg/apps/iam/individual_get.go
+++ b/api/pkg/apps/iam/individual_get.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetIndividual(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getIndividual(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	b, err := s.IndividualStore.Get(ctx, id)
+	b, err := s.individualStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, b)
+	s.json(w, http.StatusOK, b)
 }

--- a/api/pkg/apps/iam/individual_list.go
+++ b/api/pkg/apps/iam/individual_list.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListIndividuals(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listIndividuals(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	listOptions := &IndividualListOptions{}
 	if err := listOptions.UnmarshalQueryParameters(req.URL.Query()); err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	list, err := s.IndividualStore.List(ctx, *listOptions)
+	list, err := s.individualStore.list(ctx, *listOptions)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, list)
+	s.json(w, http.StatusOK, list)
 }

--- a/api/pkg/apps/iam/individual_post.go
+++ b/api/pkg/apps/iam/individual_post.go
@@ -5,16 +5,18 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostIndividual(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postIndividual(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var individual Individual
-	if err := s.Bind(req, &individual); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &individual); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	individual.ID = uuid.NewV4().String()
+	if individual.ID == "" {
+		individual.ID = uuid.NewV4().String()
+	}
 
 	attrs := map[string][]string{}
 	for key, values := range individual.Attributes {
@@ -31,10 +33,10 @@ func (s *Server) PostIndividual(w http.ResponseWriter, req *http.Request) {
 
 	individual.Attributes = attrs
 
-	if err := s.IndividualStore.Create(ctx, &individual); err != nil {
-		s.Error(w, err)
+	if err := s.individualStore.create(ctx, &individual); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, individual)
+	s.json(w, http.StatusOK, individual)
 }

--- a/api/pkg/apps/iam/individual_put.go
+++ b/api/pkg/apps/iam/individual_put.go
@@ -4,31 +4,31 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutIndividual(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putIndividual(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
 	var individual Individual
-	if err := s.Bind(req, &individual); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &individual); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	_, err := s.IndividualStore.Get(ctx, id)
+	_, err := s.individualStore.get(ctx, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	if err := s.IndividualStore.Upsert(ctx, &individual); err != nil {
+	if err := s.individualStore.upsert(ctx, &individual); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, &individual)
+	s.json(w, http.StatusOK, &individual)
 
 }

--- a/api/pkg/apps/iam/individual_store.go
+++ b/api/pkg/apps/iam/individual_store.go
@@ -17,7 +17,7 @@ func NewIndividualStore(mongoClient *mongo.Client, database string) *IndividualS
 	}
 }
 
-func (s *IndividualStore) Create(ctx context.Context, individual *Individual) error {
+func (s *IndividualStore) create(ctx context.Context, individual *Individual) error {
 	individual.AddPartyType(IndividualPartyType.ID)
 	_, err := s.collection.InsertOne(ctx, individual)
 	if err != nil {
@@ -26,7 +26,19 @@ func (s *IndividualStore) Create(ctx context.Context, individual *Individual) er
 	return nil
 }
 
-func (s *IndividualStore) Upsert(ctx context.Context, individual *Individual) error {
+func (s *IndividualStore) get(ctx context.Context, ID string) (*Individual, error) {
+	findResult := s.collection.FindOne(ctx, bson.M{"id": ID})
+	if findResult.Err() != nil {
+		return nil, findResult.Err()
+	}
+	var individual *Individual
+	if err := findResult.Decode(&individual); err != nil {
+		return nil, err
+	}
+	return individual, nil
+}
+
+func (s *IndividualStore) upsert(ctx context.Context, individual *Individual) error {
 	individual.AddPartyType(IndividualPartyType.ID)
 	_, err := s.collection.UpdateOne(ctx, bson.M{
 		"id": individual.ID,
@@ -43,19 +55,7 @@ func (s *IndividualStore) Upsert(ctx context.Context, individual *Individual) er
 	return nil
 }
 
-func (s *IndividualStore) Get(ctx context.Context, ID string) (*Individual, error) {
-	findResult := s.collection.FindOne(ctx, bson.M{"id": ID})
-	if findResult.Err() != nil {
-		return nil, findResult.Err()
-	}
-	var individual *Individual
-	if err := findResult.Decode(&individual); err != nil {
-		return nil, err
-	}
-	return individual, nil
-}
-
-func (s *IndividualStore) List(ctx context.Context, listOptions IndividualListOptions) (*IndividualList, error) {
+func (s *IndividualStore) list(ctx context.Context, listOptions IndividualListOptions) (*IndividualList, error) {
 
 	includesIndividualPartyType := false
 

--- a/api/pkg/apps/iam/individual_test.go
+++ b/api/pkg/apps/iam/individual_test.go
@@ -1,0 +1,222 @@
+// +build integration
+
+package iam_test
+
+import (
+	. "github.com/nrc-no/core/pkg/apps/iam"
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *Suite) TestIndividual() {
+	s.Run("API", func() { s.testIndividualAPI() })
+	s.SetupTest()
+	s.Run("List filtering", func() { s.testIndividualListFilter() })
+}
+
+func (s *Suite) testIndividualAPI() {
+	// CREATE
+	individual := s.mockIndividuals(1)[0]
+	created, err := s.client.Individuals().Create(s.ctx, individual)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Equal(s.T(), individual, created)
+
+	// GET
+	get, err := s.client.Individuals().Get(s.ctx, created.ID)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Equal(s.T(), created, get)
+
+	// UPDATE
+	individual.Attributes.Set(FirstNameAttribute.ID, "updated")
+	individual.Attributes.Set(LastNameAttribute.ID, "updated")
+	updated, err := s.client.Individuals().Update(s.ctx, individual)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Equal(s.T(), individual, updated)
+
+	// GET
+	get, err = s.client.Individuals().Get(s.ctx, updated.ID)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Equal(s.T(), updated, get)
+
+	// LIST
+	list, err := s.client.Individuals().List(s.ctx, IndividualListOptions{})
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Contains(s.T(), list.Items, get)
+}
+
+func (s *Suite) testIndividualListFilter() {
+	nIndividuals := 10
+	nPartyTypes := 3
+	nAttributes := 5
+
+	// Make a couple Individuals
+	individuals := s.mockIndividuals(nIndividuals)
+	// ... and a couple PartyTypes
+	partyTypes := make([]string, 0)
+	for i := 0; i < nPartyTypes; i++ {
+		partyTypes = append(partyTypes, newUUID())
+	}
+	// ... and a couple Attributes
+	attributes := make([]string, 0)
+	for i := 0; i < nAttributes; i++ {
+		attributes = append(attributes, newUUID())
+	}
+
+	// Prepare the test data
+	//individualsFromPartyTypes := make(map[string][]string)
+	//individualsFromAttributes := make(map[string][]string)
+	for i, individual := range individuals {
+		// Individuals have the IndividualPartyType by default, lets give them a couple more
+		n := i % len(partyTypes)
+		individual.PartyTypeIDs = append(individual.PartyTypeIDs, partyTypes[0:n]...)
+		//for _, partyType := range individual.PartyTypeIDs {
+		//	individualsFromPartyTypes[partyType] = append(individualsFromPartyTypes[partyType], individual.ID)
+		//}
+
+		// Individuals have the FirstName and LastName attributes by default, lets give them a couple more
+		m := i % len(attributes)
+		for _, attribute := range attributes[0:m] {
+			individual.Attributes.Set(attribute, "mock")
+			//individualsFromAttributes[attribute] = append(individualsFromAttributes[attribute], individual.ID)
+		}
+
+		// Save the individual to the DB
+		_, err := s.client.Individuals().Create(s.ctx, individual)
+		assert.NoError(s.T(), err)
+	}
+
+	s.Run("by party type", func() {
+		s.testIndividualFilterByPartyType(individuals, partyTypes)
+	})
+	s.Run("by attribute", func() {
+		s.testIndividualFilterByAttribute(individuals, attributes)
+	})
+	s.Run("by party type and attribute", func() {
+		s.testIndividualFilterByPartyTypeAndAttribute(individuals, partyTypes, attributes)
+	})
+}
+
+func (s *Suite) testIndividualFilterByPartyType(individuals []*Individual, partyTypeIds []string) {
+	for i := 1; i <= len(partyTypeIds); i++ {
+		types := append([]string{IndividualPartyType.ID}, partyTypeIds[0:i]...)
+		list, err := s.client.Individuals().List(ctx, IndividualListOptions{
+			PartyTypeIDs: types,
+		})
+		if !assert.NoError(s.T(), err) {
+			s.T().FailNow()
+		}
+		// Get expected items
+		var expected []string
+		for _, individual := range individuals {
+			var include = true
+			for _, wantedPartyTypeId := range types {
+				if !contains(individual.PartyTypeIDs, wantedPartyTypeId) {
+					include = false
+					break
+				}
+			}
+			if include {
+				expected = append(expected, individual.ID)
+			}
+		}
+
+		// Compare list lengths
+		assert.Len(s.T(), list.Items, len(expected))
+		// ... and contents
+		for _, item := range list.Items {
+			assert.Contains(s.T(), expected, item.ID)
+		}
+	}
+}
+
+func (s *Suite) testIndividualFilterByAttribute(individuals []*Individual, attributes []string) {
+	for i := 1; i <= len(attributes); i++ {
+		wantedAttributes := attributes[0:i]
+		attributesOptions := make(map[string]string)
+		for _, attribute := range wantedAttributes {
+			attributesOptions[attribute] = "mock"
+		}
+		options := IndividualListOptions{Attributes: attributesOptions}
+		list, err := s.client.Individuals().List(ctx, options)
+		assert.NoError(s.T(), err)
+
+		// Get expected items
+		var expected []string
+		for _, individual := range individuals {
+			var include = true
+			for id := range attributesOptions {
+				if !individual.HasAttribute(id) {
+					include = false
+					break
+				}
+			}
+			if include {
+				expected = append(expected, individual.ID)
+			}
+		}
+
+		// Compare list lengths
+		assert.Len(s.T(), list.Items, len(expected))
+		// ... and contents
+		for _, item := range list.Items {
+			assert.Contains(s.T(), expected, item.ID)
+		}
+	}
+}
+
+func (s *Suite) testIndividualFilterByPartyTypeAndAttribute(individuals []*Individual, types []string, attributes []string) {
+	for i := 1; i <= len(attributes); i++ {
+		for j := 1; i <= len(types); i++ {
+			partyTypeIds := append([]string{IndividualPartyType.ID}, types[0:j]...)
+			attributeOptions := make(map[string]string)
+			for _, attribute := range attributes[0:i] {
+				attributeOptions[attribute] = "mock"
+			}
+			list, err := s.client.Individuals().List(ctx, IndividualListOptions{
+				PartyTypeIDs: partyTypeIds,
+				Attributes:   attributeOptions,
+			})
+			if !assert.NoError(s.T(), err) {
+				s.T().FailNow()
+			}
+			// Get expected items
+			var expected []string
+			for _, individual := range individuals {
+				var include = true
+				for _, partyType := range partyTypeIds {
+					if !contains(individual.PartyTypeIDs, partyType) {
+						include = false
+						break
+					}
+				}
+				if include {
+					for id := range attributeOptions {
+						if !individual.HasAttribute(id) {
+							include = false
+							break
+						}
+					}
+				}
+				if include {
+					expected = append(expected, individual.ID)
+				}
+			}
+
+			// Compare list lengths
+			assert.Len(s.T(), expected, len(list.Items))
+			// ... and contents
+			for _, item := range list.Items {
+				assert.Contains(s.T(), expected, item.ID)
+			}
+		}
+	}
+}

--- a/api/pkg/apps/iam/init.go
+++ b/api/pkg/apps/iam/init.go
@@ -7,15 +7,15 @@ import (
 
 func (s *Server) Init(ctx context.Context) error {
 
-	if err := s.InitPartyType(ctx); err != nil {
+	if err := s.initPartyType(ctx); err != nil {
 		return err
 	}
 
-	if err := s.InitRelationshipType(ctx); err != nil {
+	if err := s.initRelationshipType(ctx); err != nil {
 		return err
 	}
 
-	if err := s.InitAttribute(ctx); err != nil {
+	if err := s.initAttribute(ctx); err != nil {
 		return err
 	}
 
@@ -23,18 +23,18 @@ func (s *Server) Init(ctx context.Context) error {
 
 }
 
-func (s *Server) InitPartyType(ctx context.Context) error {
+func (s *Server) initPartyType(ctx context.Context) error {
 	for _, partyType := range []PartyType{
 		IndividualPartyType,
 		HouseholdPartyType,
 		TeamPartyType,
 		StaffPartyType,
 	} {
-		if err := s.PartyTypeStore.Create(ctx, &partyType); err != nil {
+		if err := s.partyTypeStore.Create(ctx, &partyType); err != nil {
 			if !mongo.IsDuplicateKeyError(err) {
 				return err
 			}
-			if err := s.PartyTypeStore.Update(ctx, &partyType); err != nil {
+			if err := s.partyTypeStore.Update(ctx, &partyType); err != nil {
 				return err
 			}
 		}
@@ -42,7 +42,7 @@ func (s *Server) InitPartyType(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) InitRelationshipType(ctx context.Context) error {
+func (s *Server) initRelationshipType(ctx context.Context) error {
 	for _, relationshipType := range []RelationshipType{
 		HeadOfHouseholdRelationshipType,
 		SpousalRelationshipType,
@@ -50,11 +50,11 @@ func (s *Server) InitRelationshipType(ctx context.Context) error {
 		ParentalRelationshipType,
 		MembershipRelationshipType,
 	} {
-		if err := s.RelationshipTypeStore.Create(ctx, &relationshipType); err != nil {
+		if err := s.relationshipTypeStore.Create(ctx, &relationshipType); err != nil {
 			if !mongo.IsDuplicateKeyError(err) {
 				return err
 			}
-			if err := s.RelationshipTypeStore.Update(ctx, &relationshipType); err != nil {
+			if err := s.relationshipTypeStore.Update(ctx, &relationshipType); err != nil {
 				return err
 			}
 		}
@@ -62,7 +62,7 @@ func (s *Server) InitRelationshipType(ctx context.Context) error {
 	return nil
 }
 
-func (s *Server) InitAttribute(ctx context.Context) error {
+func (s *Server) initAttribute(ctx context.Context) error {
 	for _, attribute := range []Attribute{
 		FirstNameAttribute,
 		LastNameAttribute,
@@ -70,11 +70,11 @@ func (s *Server) InitAttribute(ctx context.Context) error {
 		EMailAttribute,
 		TeamNameAttribute,
 	} {
-		if err := s.AttributeStore.Create(ctx, &attribute); err != nil {
+		if err := s.attributeStore.create(ctx, &attribute); err != nil {
 			if !mongo.IsDuplicateKeyError(err) {
 				return err
 			}
-			if err := s.AttributeStore.Update(ctx, &attribute); err != nil {
+			if err := s.attributeStore.update(ctx, &attribute); err != nil {
 				return err
 			}
 		}

--- a/api/pkg/apps/iam/membership_get.go
+++ b/api/pkg/apps/iam/membership_get.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetMembership(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getMembership(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
-	ret, err := s.MembershipStore.Get(ctx, id)
+	ret, err := s.membershipStore.get(ctx, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 
 }

--- a/api/pkg/apps/iam/membership_list.go
+++ b/api/pkg/apps/iam/membership_list.go
@@ -2,7 +2,7 @@ package iam
 
 import "net/http"
 
-func (s *Server) ListMemberships(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listMemberships(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var listOptions MembershipListOptions
@@ -11,11 +11,11 @@ func (s *Server) ListMemberships(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ret, err := s.MembershipStore.List(ctx, listOptions)
+	ret, err := s.membershipStore.list(ctx, listOptions)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/membership_post.go
+++ b/api/pkg/apps/iam/membership_post.go
@@ -5,23 +5,26 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostMembership(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postMembership(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var payload Membership
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	p := &payload
-	p.ID = uuid.NewV4().String()
 
-	if err := s.MembershipStore.Create(ctx, p); err != nil {
+	if p.ID == "" {
+		p.ID = uuid.NewV4().String()
+	}
+
+	if err := s.membershipStore.create(ctx, p); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, p)
+	s.json(w, http.StatusOK, p)
 
 }

--- a/api/pkg/apps/iam/membership_store.go
+++ b/api/pkg/apps/iam/membership_store.go
@@ -14,9 +14,9 @@ func NewMembershipStore(relationshipStore *RelationshipStore) *MembershipStore {
 	return &MembershipStore{relationshipStore: relationshipStore}
 }
 
-func (s *MembershipStore) List(ctx context.Context, listOptions MembershipListOptions) (*MembershipList, error) {
+func (s *MembershipStore) list(ctx context.Context, listOptions MembershipListOptions) (*MembershipList, error) {
 
-	got, err := s.relationshipStore.List(ctx, RelationshipListOptions{
+	got, err := s.relationshipStore.list(ctx, RelationshipListOptions{
 		RelationshipTypeID: MembershipRelationshipType.ID,
 		FirstPartyID:       listOptions.IndividualID,
 		SecondPartyID:      listOptions.TeamID,
@@ -36,8 +36,8 @@ func (s *MembershipStore) List(ctx context.Context, listOptions MembershipListOp
 
 }
 
-func (s *MembershipStore) Get(ctx context.Context, id string) (*Membership, error) {
-	got, err := s.relationshipStore.Get(ctx, id)
+func (s *MembershipStore) get(ctx context.Context, id string) (*Membership, error) {
+	got, err := s.relationshipStore.get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +49,8 @@ func (s *MembershipStore) Get(ctx context.Context, id string) (*Membership, erro
 
 }
 
-func (s *MembershipStore) Find(ctx context.Context, individualId, teamId string) (*Membership, error) {
-	got, err := s.relationshipStore.List(ctx, RelationshipListOptions{
+func (s *MembershipStore) find(ctx context.Context, individualId, teamId string) (*Membership, error) {
+	got, err := s.relationshipStore.list(ctx, RelationshipListOptions{
 		RelationshipTypeID: MembershipRelationshipType.ID,
 		FirstPartyID:       individualId,
 		SecondPartyID:      teamId,
@@ -64,8 +64,8 @@ func (s *MembershipStore) Find(ctx context.Context, individualId, teamId string)
 	return MapRelationshipToMembership(got.Items[0]), nil
 }
 
-func (s *MembershipStore) Create(ctx context.Context, membership *Membership) error {
-	got, err := s.Find(ctx, membership.IndividualID, membership.TeamID)
+func (s *MembershipStore) create(ctx context.Context, membership *Membership) error {
+	got, err := s.find(ctx, membership.IndividualID, membership.TeamID)
 	if err != nil {
 		return err
 	}
@@ -73,8 +73,10 @@ func (s *MembershipStore) Create(ctx context.Context, membership *Membership) er
 		return nil
 	}
 	rel := MapMembershipToRelationship(membership)
-	rel.ID = uuid.NewV4().String()
-	return s.relationshipStore.Create(ctx, rel)
+	if rel.ID == "" {
+		rel.ID = uuid.NewV4().String()
+	}
+	return s.relationshipStore.create(ctx, rel)
 }
 
 func MapRelationshipToMembership(rel *Relationship) *Membership {

--- a/api/pkg/apps/iam/membership_test.go
+++ b/api/pkg/apps/iam/membership_test.go
@@ -1,0 +1,56 @@
+// +build integration
+
+package iam_test
+
+import (
+	. "github.com/nrc-no/core/pkg/apps/iam"
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *Suite) TestMembership() {
+	s.Run("API", func() { s.testMembershipAPI() })
+}
+
+func (s *Suite) testMembershipAPI() {
+	membership := s.mockMemberships(1)[0]
+	membership.TeamID = newUUID()
+	membership.IndividualID = newUUID()
+
+	// Create
+	created, err := s.client.Memberships().Create(s.ctx, membership)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Equal(s.T(), membership, created)
+
+	// Get
+	get, err := s.client.Memberships().Get(s.ctx, created.ID)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Equal(s.T(), created, get)
+
+	// NB Membership doesn't implement UPDATE for now
+	//// Update
+	//membership.TeamID = newUUID()
+	//membership.IndividualID = newUUID()
+	//updated, err := s.client.Memberships().Update(s.ctx, &membership)
+	//if !assert.NoError(s.T(), err) {
+	//	s.T().FailNow()
+	//}
+	//assert.Equal(s.T(), membership, *updated)
+	//
+	//// Get
+	//get, err = s.client.Memberships().Get(s.ctx, updated.ID)
+	//if !assert.NoError(s.T(), err) {
+	//	s.T().FailNow()
+	//}
+	//assert.Equal(s.T(), updated, get)
+
+	// List
+	list, err := s.client.Memberships().List(s.ctx, MembershipListOptions{})
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	assert.Contains(s.T(), list.Items, get)
+}

--- a/api/pkg/apps/iam/party_get.go
+++ b/api/pkg/apps/iam/party_get.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetParty(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getParty(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	ret, err := s.PartyStore.Get(ctx, id)
+	ret, err := s.partyStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/party_list.go
+++ b/api/pkg/apps/iam/party_list.go
@@ -4,12 +4,12 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListParties(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listParties(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	listOptions := &PartyListOptions{}
 	if err := listOptions.UnmarshalQueryParameters(req.URL.Query()); err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
@@ -21,11 +21,11 @@ func (s *Server) ListParties(w http.ResponseWriter, req *http.Request) {
 		options.PartyTypeIDs = []string{listOptions.PartyTypeID}
 	}
 
-	ret, err := s.PartyStore.List(ctx, *options)
+	ret, err := s.partyStore.list(ctx, *options)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/party_post.go
+++ b/api/pkg/apps/iam/party_post.go
@@ -5,22 +5,25 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostParty(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postParty(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var party Party
-	if err := s.Bind(req, &party); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &party); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	p := &party
-	p.ID = uuid.NewV4().String()
 
-	if err := s.PartyStore.Create(ctx, p); err != nil {
+	if p.ID == "" {
+		p.ID = uuid.NewV4().String()
+	}
+
+	if err := s.partyStore.create(ctx, p); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, p)
+	s.json(w, http.StatusOK, p)
 }

--- a/api/pkg/apps/iam/party_put.go
+++ b/api/pkg/apps/iam/party_put.go
@@ -4,33 +4,33 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutParty(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putParty(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	r, err := s.PartyStore.Get(ctx, id)
+	r, err := s.partyStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
 	var payload Party
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	r.Attributes = payload.Attributes
 	r.PartyTypeIDs = payload.PartyTypeIDs
 
-	if err := s.PartyStore.Update(ctx, r); err != nil {
-		s.Error(w, err)
+	if err := s.partyStore.update(ctx, r); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, r)
+	s.json(w, http.StatusOK, r)
 }

--- a/api/pkg/apps/iam/party_search.go
+++ b/api/pkg/apps/iam/party_search.go
@@ -4,24 +4,24 @@ import (
 	"net/http"
 )
 
-func (s *Server) SearchParties(w http.ResponseWriter, req *http.Request) {
+func (s *Server) searchParties(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var listOptions PartySearchOptions
-	if err := s.Bind(req, &listOptions); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &listOptions); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	ret, err := s.PartyStore.List(ctx, PartySearchOptions{
+	ret, err := s.partyStore.list(ctx, PartySearchOptions{
 		PartyTypeIDs: listOptions.PartyTypeIDs,
 		Attributes:   listOptions.Attributes,
 		SearchParam:  listOptions.SearchParam,
 	})
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/party_store.go
+++ b/api/pkg/apps/iam/party_store.go
@@ -11,7 +11,7 @@ type PartyStore struct {
 	Collection *mongo.Collection
 }
 
-func NewPartyStore(ctx context.Context, mongoClient *mongo.Client, database string) (*PartyStore, error) {
+func newPartyStore(ctx context.Context, mongoClient *mongo.Client, database string) (*PartyStore, error) {
 	store := &PartyStore{
 		Collection: mongoClient.Database(database).Collection("parties"),
 	}
@@ -40,7 +40,7 @@ func NewPartyStore(ctx context.Context, mongoClient *mongo.Client, database stri
 	return store, nil
 }
 
-func (s *PartyStore) Get(ctx context.Context, id string) (*Party, error) {
+func (s *PartyStore) get(ctx context.Context, id string) (*Party, error) {
 	res := s.Collection.FindOne(ctx, bson.M{
 		"id": id,
 	})
@@ -62,7 +62,7 @@ func BSONStringA(strSlice []string) (result bson.A) {
 	return
 }
 
-func (s *PartyStore) List(ctx context.Context, listOptions PartySearchOptions) (*PartyList, error) {
+func (s *PartyStore) list(ctx context.Context, listOptions PartySearchOptions) (*PartyList, error) {
 	filterItems := bson.M{}
 
 	if len(listOptions.PartyTypeIDs) != 0 {
@@ -110,7 +110,7 @@ func (s *PartyStore) List(ctx context.Context, listOptions PartySearchOptions) (
 	return &ret, nil
 }
 
-func (s *PartyStore) Update(ctx context.Context, party *Party) error {
+func (s *PartyStore) update(ctx context.Context, party *Party) error {
 	_, err := s.Collection.UpdateOne(ctx, bson.M{
 		"id": party.ID,
 	}, bson.M{
@@ -125,7 +125,7 @@ func (s *PartyStore) Update(ctx context.Context, party *Party) error {
 	return nil
 }
 
-func (s *PartyStore) Create(ctx context.Context, party *Party) error {
+func (s *PartyStore) create(ctx context.Context, party *Party) error {
 	_, err := s.Collection.InsertOne(ctx, party)
 	if err != nil {
 		return err
@@ -137,7 +137,7 @@ type FindOptions struct {
 	Attributes map[string]string
 }
 
-func (s *PartyStore) Find(ctx context.Context, options FindOptions) (*Party, error) {
+func (s *PartyStore) find(ctx context.Context, options FindOptions) (*Party, error) {
 	filter := bson.M{}
 	for key, value := range options.Attributes {
 		filter["attributes."+key] = value

--- a/api/pkg/apps/iam/partytype_get.go
+++ b/api/pkg/apps/iam/partytype_get.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetPartyType(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getPartyType(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	ret, err := s.PartyTypeStore.Get(ctx, id)
+	ret, err := s.partyTypeStore.Get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 
 }

--- a/api/pkg/apps/iam/partytype_list.go
+++ b/api/pkg/apps/iam/partytype_list.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListPartyTypes(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listPartyTypes(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	listOptions := &PartyTypeListOptions{}
 	if err := listOptions.UnmarshalQueryParameters(req.URL.Query()); err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	ret, err := s.PartyTypeStore.List(ctx, *listOptions)
+	ret, err := s.partyTypeStore.List(ctx, *listOptions)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/partytype_post.go
+++ b/api/pkg/apps/iam/partytype_post.go
@@ -5,22 +5,22 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostPartyType(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postPartyType(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var payload PartyType
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	p := &payload
 	p.ID = uuid.NewV4().String()
 
-	if err := s.PartyTypeStore.Create(ctx, p); err != nil {
-		s.Error(w, err)
+	if err := s.partyTypeStore.Create(ctx, p); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, p)
+	s.json(w, http.StatusOK, p)
 }

--- a/api/pkg/apps/iam/partytype_put.go
+++ b/api/pkg/apps/iam/partytype_put.go
@@ -4,33 +4,33 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutPartyType(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putPartyType(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	r, err := s.PartyTypeStore.Get(ctx, id)
+	r, err := s.partyTypeStore.Get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
 	var payload PartyType
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	r.Name = payload.Name
 	r.IsBuiltIn = payload.IsBuiltIn
 
-	if err := s.PartyTypeStore.Update(ctx, r); err != nil {
-		s.Error(w, err)
+	if err := s.partyTypeStore.Update(ctx, r); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, r)
+	s.json(w, http.StatusOK, r)
 }

--- a/api/pkg/apps/iam/partytype_store.go
+++ b/api/pkg/apps/iam/partytype_store.go
@@ -11,7 +11,7 @@ type PartyTypeStore struct {
 	collection *mongo.Collection
 }
 
-func NewPartyTypeStore(ctx context.Context, mongoClient *mongo.Client, database string) (*PartyTypeStore, error) {
+func newPartyTypeStore(ctx context.Context, mongoClient *mongo.Client, database string) (*PartyTypeStore, error) {
 	store := &PartyTypeStore{
 		collection: mongoClient.Database(database).Collection("partyTypes"),
 	}

--- a/api/pkg/apps/iam/partytype_test.go
+++ b/api/pkg/apps/iam/partytype_test.go
@@ -1,16 +1,16 @@
 // +build integration
 
-package iam
+package iam_test
 
 import (
-	uuid "github.com/satori/go.uuid"
+	. "github.com/nrc-no/core/pkg/apps/iam"
 	"github.com/stretchr/testify/assert"
 )
 
-func (s *Suite) TestPartyTypeCRUD() {
+func (s *Suite) TestPartyType() {
 
 	// Create party type
-	name := uuid.NewV4().String()
+	name := newUUID()
 	created, err := s.client.PartyTypes().Create(s.ctx, &PartyType{
 		Name:      name,
 		IsBuiltIn: false,

--- a/api/pkg/apps/iam/relationship_delete.go
+++ b/api/pkg/apps/iam/relationship_delete.go
@@ -4,17 +4,17 @@ import (
 	"net/http"
 )
 
-func (s *Server) DeleteRelationship(w http.ResponseWriter, req *http.Request) {
+func (s *Server) deleteRelationship(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	err := s.RelationshipStore.Delete(ctx, id)
+	err := s.relationshipStore.delete(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 }

--- a/api/pkg/apps/iam/relationship_get.go
+++ b/api/pkg/apps/iam/relationship_get.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetRelationship(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getRelationship(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	ret, err := s.RelationshipStore.Get(ctx, id)
+	ret, err := s.relationshipStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/relationship_list.go
+++ b/api/pkg/apps/iam/relationship_list.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListRelationships(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listRelationships(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	listOptions := &RelationshipListOptions{}
 	if err := listOptions.UnmarshalQueryParameters(req.URL.Query()); err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	ret, err := s.RelationshipStore.List(ctx, *listOptions)
+	ret, err := s.relationshipStore.list(ctx, *listOptions)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/relationship_post.go
+++ b/api/pkg/apps/iam/relationship_post.go
@@ -5,22 +5,25 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostRelationship(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postRelationship(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var payload Relationship
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	p := &payload
-	p.ID = uuid.NewV4().String()
 
-	if err := s.RelationshipStore.Create(ctx, p); err != nil {
-		s.Error(w, err)
+	if p.ID == "" {
+		p.ID = uuid.NewV4().String()
+	}
+
+	if err := s.relationshipStore.create(ctx, p); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, p)
+	s.json(w, http.StatusOK, p)
 }

--- a/api/pkg/apps/iam/relationship_put.go
+++ b/api/pkg/apps/iam/relationship_put.go
@@ -4,23 +4,23 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutRelationship(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putRelationship(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	r, err := s.RelationshipStore.Get(ctx, id)
+	r, err := s.relationshipStore.get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
 	var payload Relationship
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
@@ -29,10 +29,10 @@ func (s *Server) PutRelationship(w http.ResponseWriter, req *http.Request) {
 	r.FirstPartyID = payload.FirstPartyID
 	r.SecondPartyID = payload.SecondPartyID
 
-	if err := s.RelationshipStore.Update(ctx, r); err != nil {
-		s.Error(w, err)
+	if err := s.relationshipStore.update(ctx, r); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, r)
+	s.json(w, http.StatusOK, r)
 }

--- a/api/pkg/apps/iam/relationship_test.go
+++ b/api/pkg/apps/iam/relationship_test.go
@@ -1,30 +1,32 @@
 // +build integration
 
-package iam
+package iam_test
 
 import (
+	. "github.com/nrc-no/core/pkg/apps/iam"
 	"github.com/stretchr/testify/assert"
-	"math/rand"
-	"strconv"
-	"testing"
 )
 
-func (s *Suite) TestRelationshipCRUD() {
+func (s *Suite) TestRelationship() {
+	s.Run("API", func() { s.testRelationshipAPI() })
+	s.SetupTest()
+	s.Run("List filtering", func() { s.testRelationshipListFilter() })
+}
 
+func (s *Suite) testRelationshipAPI() {
 	// CREATE relationship
-	mock := "create"
-	created, err := s.client.Relationships().Create(s.ctx, &Relationship{
-		RelationshipTypeID: mock,
-		FirstPartyID:       mock,
-		SecondPartyID:      mock,
-	})
+	relationship := s.mockRelationships(1)[0]
+	relationship.RelationshipTypeID = newUUID()
+	relationship.FirstPartyID = newUUID()
+	relationship.SecondPartyID = newUUID()
+	created, err := s.client.Relationships().Create(s.ctx, relationship)
 	if !assert.NoError(s.T(), err) {
 		return
 	}
-	assert.NotEmpty(s.T(), created.ID)
-	assert.Equal(s.T(), mock, created.RelationshipTypeID)
-	assert.Equal(s.T(), mock, created.FirstPartyID)
-	assert.Equal(s.T(), mock, created.SecondPartyID)
+	assert.Equal(s.T(), relationship.ID, created.ID)
+	assert.Equal(s.T(), relationship.RelationshipTypeID, created.RelationshipTypeID)
+	assert.Equal(s.T(), relationship.FirstPartyID, created.FirstPartyID)
+	assert.Equal(s.T(), relationship.SecondPartyID, created.SecondPartyID)
 
 	// GET relationship
 	get, err := s.client.Relationships().Get(s.ctx, created.ID)
@@ -34,21 +36,18 @@ func (s *Suite) TestRelationshipCRUD() {
 	assert.Equal(s.T(), created, get)
 
 	// UPDATE relationships type
-	updatedMock := "update"
+	relationship.RelationshipTypeID = newUUID()
+	relationship.FirstPartyID = newUUID()
+	relationship.SecondPartyID = newUUID()
 
-	updated, err := s.client.Relationships().Update(s.ctx, &Relationship{
-		ID:                 created.ID,
-		RelationshipTypeID: updatedMock,
-		FirstPartyID:       updatedMock,
-		SecondPartyID:      updatedMock,
-	})
+	updated, err := s.client.Relationships().Update(s.ctx, relationship)
 	if !assert.NoError(s.T(), err) {
 		return
 	}
-	assert.Equal(s.T(), created.ID, updated.ID)
-	assert.Equal(s.T(), updatedMock, updated.RelationshipTypeID)
-	assert.Equal(s.T(), updatedMock, updated.FirstPartyID)
-	assert.Equal(s.T(), updatedMock, updated.SecondPartyID)
+	assert.Equal(s.T(), relationship.ID, updated.ID)
+	assert.Equal(s.T(), relationship.RelationshipTypeID, updated.RelationshipTypeID)
+	assert.Equal(s.T(), relationship.FirstPartyID, updated.FirstPartyID)
+	assert.Equal(s.T(), relationship.SecondPartyID, updated.SecondPartyID)
 
 	// GET relationships type
 	get, err = s.client.Relationships().Get(s.ctx, updated.ID)
@@ -66,257 +65,200 @@ func (s *Suite) TestRelationshipCRUD() {
 	assert.Contains(s.T(), list.Items, get)
 }
 
-type MockRelationship struct {
-	RelationshipTypeID string
-	FirstParty         string
-	SecondParty        string
+func (s *Suite) testRelationshipListFilter() {
+	nRelationships := 10
+	nRelationshipTypes := 3
+	nParties := 4
+
+	relationships := s.mockRelationships(nRelationships)
+	relationshipTypes := s.mockRelationshipTypes(nRelationshipTypes)
+	parties := s.mockParties(nParties)
+
+	relationshipsFromTypes := make(map[string][]string)
+	relationshipsFromFirstParties := make(map[string][]string)
+	relationshipsFromSecondParties := make(map[string][]string)
+	relationshipsFromEitherParties := make(map[string][]string)
+	relationshipsFromBoth := make(map[string][]string)
+	relationshipsFromTypeAndEither := make(map[string][]string)
+	relationshipsFromTypeAndBoth := make(map[string][]string)
+
+	// Prepare test data
+	for i, relationship := range relationships {
+		// Assign field values to the empty relationships
+		rType := relationshipTypes[i%len(relationshipTypes)].ID
+		party1 := parties[i%len(parties)].ID
+		party2 := parties[(i+1)%len(parties)].ID
+		relationship.RelationshipTypeID = rType
+		relationship.FirstPartyID = party1
+		relationship.SecondPartyID = party2
+
+		// Save the relationship to the DB
+		_, err := s.client.Relationships().Create(s.ctx, relationship)
+		if !assert.NoError(s.T(), err) {
+			s.T().FailNow()
+		}
+
+		// Maps the fields to the relationship
+		id := relationship.ID
+		relationshipsFromTypes[rType] = append(relationshipsFromTypes[rType], id)
+		relationshipsFromFirstParties[party1] = append(relationshipsFromFirstParties[party1], id)
+		relationshipsFromSecondParties[party2] = append(relationshipsFromSecondParties[party2], id)
+		relationshipsFromEitherParties[party1] = append(relationshipsFromEitherParties[party1], id)
+		relationshipsFromEitherParties[party2] = append(relationshipsFromEitherParties[party2], id)
+		relationshipsFromBoth[party1+party2] = append(relationshipsFromBoth[party1+party2], id)
+		relationshipsFromTypeAndEither[rType+party1] = append(relationshipsFromTypeAndEither[rType+party1], id)
+		relationshipsFromTypeAndEither[rType+party2] = append(relationshipsFromTypeAndEither[rType+party2], id)
+		relationshipsFromTypeAndBoth[rType+party1+party2] = append(relationshipsFromTypeAndBoth[rType+party1+party2], id)
+	}
+
+	s.Run("by type", func() { s.testRelationshipFilterByType(relationshipsFromTypes, relationshipTypes) })
+	s.Run("by first party", func() { s.testRelationshipFilterByFirstParty(relationshipsFromFirstParties, parties) })
+	s.Run("by second party", func() { s.testRelationshipFilterBySecondParty(relationshipsFromSecondParties, parties) })
+	s.Run("by either party", func() { s.testRelationshipFilterByEitherParty(relationshipsFromEitherParties, parties) })
+	s.Run("by both parties", func() { s.testRelationshipFilterByBothParties(relationshipsFromBoth, parties) })
+	s.Run("by type and either party", func() {
+		s.testRelationshipFilterByTypeAndEither(relationshipsFromTypeAndEither, relationshipTypes, parties)
+	})
+	s.Run("by type and both parties", func() {
+		s.testRelationshipFilterByTypeAndBoth(relationshipsFromTypeAndBoth, relationshipTypes, parties)
+	})
 }
 
-// Test variables
-var (
-	mockRelationships       []*MockRelationship
-	numMockRelationships    = 20
-	mockRelationshipTypeIDs = [3]string{"a", "b", "c"}
-	mockParties             = make([]string, 0)
-	numMockParties          = 10
-	// maps of fields to relationships
-	byRelationshipTypeID             = map[string][]*Relationship{}
-	byFirstParty                     = map[string][]*Relationship{}
-	bySecondParty                    = map[string][]*Relationship{}
-	byEitherParty                    = map[string][]*Relationship{}
-	byParties                        = map[string][]*Relationship{}
-	byRelTypeIDFirstAndSecondParties = map[string][]*Relationship{}
-	byRelTypeIDAndEitherParty        = map[string][]*Relationship{}
-)
-
-func (s *Suite) TestRelationshipListFilterByListOptions() {
-	s.ResetDB()
-
-	mockRelationships := prepareMockRelationships()
-
-	// Create the relationships
-	for _, mock := range mockRelationships {
-		r, err := s.client.Relationships().Create(s.ctx, &Relationship{
-			RelationshipTypeID: mock.RelationshipTypeID,
-			FirstPartyID:       mock.FirstParty,
-			SecondPartyID:      mock.SecondParty,
+func (s *Suite) testRelationshipFilterByType(expected map[string][]string, types []*RelationshipType) {
+	for _, relationshipType := range types {
+		rType := relationshipType.ID
+		list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
+			RelationshipTypeID: rType,
 		})
 		if !assert.NoError(s.T(), err) {
-			return
+			s.T().FailNow()
 		}
-		// Add to maps
-		populateMaps(mock, r)
+		// map entry and returned list should have the same length
+		assert.Len(s.T(), expected[rType], len(list.Items))
+		// map entry should contain same items as list
+		for _, l := range list.Items {
+			assert.Contains(s.T(), expected[rType], l.ID)
+		}
 	}
-
-	// Ensure we created enough entries
-	list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{})
-	if !assert.NoError(s.T(), err) {
-		return
-	}
-	if l := len(list.Items); l != numMockRelationships {
-		s.T().Logf("Incorrect number of DB entries created. expected: %d actual: %d", numMockRelationships, l)
-		s.T().Fatal()
-	}
-
-	// Actual tests
-	s.filter_by_RelationshipTypeID()
-
-	s.filter_by_firstPartyID()
-
-	s.filter_by_SecondPartyID()
-
-	s.filter_by_EitherParty()
-
-	s.filter_by_RelTypeID_and_EitherParty()
-
-	s.filter_by_First_and_SecondParty()
-
-	s.filter_by_RelTypeID_First_and_SecondParty()
 }
 
-func prepareMockRelationships() []*MockRelationship {
-	for i := 0; i < numMockParties; i++ {
-		mockParties = append(mockParties, strconv.Itoa(i))
-	}
-
-	for i := 0; i < numMockRelationships; i++ {
-		p1 := mockParties[rand.Intn(len(mockParties))]
-		p2 := p1
-		for p2 == p1 {
-			p2 = mockParties[rand.Intn(len(mockParties))]
-		}
-		mockRelationships = append(mockRelationships, &MockRelationship{
-			mockRelationshipTypeIDs[rand.Intn(len(mockRelationshipTypeIDs))],
-			p1,
-			p2,
+func (s *Suite) testRelationshipFilterByFirstParty(expected map[string][]string, parties []*Party) {
+	for _, party := range parties {
+		list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
+			FirstPartyID: party.ID,
 		})
+		if !assert.NoError(s.T(), err) {
+			s.T().FailNow()
+		}
+		// map entry and returned list should have the same length
+		assert.Len(s.T(), expected[party.ID], len(list.Items))
+		// map entry should contain same items as list
+		for _, l := range list.Items {
+			assert.Contains(s.T(), expected[party.ID], l.ID)
+		}
 	}
-	return mockRelationships
 }
 
-func populateMaps(mock *MockRelationship, r *Relationship) {
-	byRelationshipTypeID[mock.RelationshipTypeID] = append(byRelationshipTypeID[mock.RelationshipTypeID], r)
-	byFirstParty[mock.FirstParty] = append(byFirstParty[mock.FirstParty], r)
-	bySecondParty[mock.SecondParty] = append(bySecondParty[mock.SecondParty], r)
-	byEitherParty[mock.FirstParty] = append(byEitherParty[mock.FirstParty], r)
-	byEitherParty[mock.SecondParty] = append(byEitherParty[mock.SecondParty], r)
-	byRelTypeIDAndEitherParty[mock.RelationshipTypeID+mock.FirstParty] = append(byRelTypeIDAndEitherParty[mock.RelationshipTypeID+mock.FirstParty], r)
-	byRelTypeIDAndEitherParty[mock.RelationshipTypeID+mock.SecondParty] = append(byRelTypeIDAndEitherParty[mock.RelationshipTypeID+mock.SecondParty], r)
-	firstAndSecond := mock.FirstParty + mock.SecondParty
-	byParties[firstAndSecond] = append(byParties[firstAndSecond], r)
-	rfs := mock.RelationshipTypeID + firstAndSecond
-	byRelTypeIDFirstAndSecondParties[rfs] = append(byRelTypeIDFirstAndSecondParties[rfs], r)
+func (s *Suite) testRelationshipFilterBySecondParty(expected map[string][]string, parties []*Party) {
+	for _, party := range parties {
+		list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
+			SecondPartyID: party.ID,
+		})
+		if !assert.NoError(s.T(), err) {
+			s.T().FailNow()
+		}
+		// map entry and returned list should have the same length
+		assert.Len(s.T(), expected[party.ID], len(list.Items))
+		// map entry should contain same items as list
+		for _, l := range list.Items {
+			assert.Contains(s.T(), expected[party.ID], l.ID)
+		}
+	}
 }
 
-func (s *Suite) filter_by_RelationshipTypeID() bool {
-	return s.T().Run("Filter by RelationshipTypeID", func(t *testing.T) {
-		for _, mockRelTypeID := range mockRelationshipTypeIDs {
-			list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-				RelationshipTypeID: mockRelTypeID,
-			})
-			if !assert.NoError(t, err) {
-				return
+func (s *Suite) testRelationshipFilterByEitherParty(expected map[string][]string, parties []*Party) {
+	for _, party := range parties {
+		list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
+			EitherPartyID: party.ID,
+		})
+		if !assert.NoError(s.T(), err) {
+			s.T().FailNow()
+		}
+		// map entry and returned list should have the same length
+		assert.Len(s.T(), expected[party.ID], len(list.Items))
+		// map entry should contain same items as list
+		for _, l := range list.Items {
+			assert.Contains(s.T(), expected[party.ID], l.ID)
+		}
+	}
+}
+
+func (s *Suite) testRelationshipFilterByBothParties(expected map[string][]string, parties []*Party) {
+	for _, party1 := range parties {
+		for _, party2 := range parties {
+			if party1.ID == party2.ID {
+				continue
 			}
+			list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
+				FirstPartyID:  party1.ID,
+				SecondPartyID: party2.ID,
+			})
+			if !assert.NoError(s.T(), err) {
+				s.T().FailNow()
+			}
+			key := party1.ID + party2.ID
 			// map entry and returned list should have the same length
-			assert.Len(t, byRelationshipTypeID[mockRelTypeID], len(list.Items))
+			assert.Len(s.T(), expected[key], len(list.Items))
 			// map entry should contain same items as list
 			for _, l := range list.Items {
-				assert.Contains(t, byRelationshipTypeID[mockRelTypeID], l)
+				assert.Contains(s.T(), expected[key], l.ID)
 			}
 		}
-	})
+	}
 }
 
-func (s *Suite) filter_by_RelTypeID_First_and_SecondParty() bool {
-	return s.T().Run("Filter by combinations of RelTypeID, First- and SecondPartyID", func(t *testing.T) {
-		for _, mockRelTypeID := range mockRelationshipTypeIDs {
-			for _, mockParty1 := range mockParties {
-				for _, mockParty2 := range mockParties {
-					if mockParty1 == mockParty2 {
-						continue
-					}
-					list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-						RelationshipTypeID: mockRelTypeID,
-						FirstPartyID:       mockParty1,
-						SecondPartyID:      mockParty2,
-					})
-					if !assert.NoError(t, err) {
-						return
-					}
-					key := mockRelTypeID + mockParty1 + mockParty2
-					// map entry and returned list should have the same length
-					assert.Len(t, byRelTypeIDFirstAndSecondParties[key], len(list.Items))
-					// map entry should contain same items as list
-					for _, l := range list.Items {
-						assert.Contains(t, byRelTypeIDFirstAndSecondParties[key], l)
-					}
-				}
+func (s *Suite) testRelationshipFilterByTypeAndEither(expected map[string][]string, types []*RelationshipType, parties []*Party) {
+	for _, relationshipType := range types {
+		rType := relationshipType.ID
+		for _, party := range parties {
+			list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
+				RelationshipTypeID: rType,
+				EitherPartyID:      party.ID,
+			})
+			if !assert.NoError(s.T(), err) {
+				s.T().FailNow()
+			}
+			key := rType + party.ID
+			// map entry and returned list should have the same length
+			assert.Len(s.T(), expected[key], len(list.Items))
+			// map entry should contain same items as list
+			for _, l := range list.Items {
+				assert.Contains(s.T(), expected[key], l.ID)
 			}
 		}
-	})
+	}
 }
-
-func (s *Suite) filter_by_First_and_SecondParty() bool {
-	return s.T().Run("Filter by combinations of First- and SecondPartyID", func(t *testing.T) {
-		for _, mockParty1 := range mockParties {
-			for _, mockParty2 := range mockParties {
-				if mockParty1 == mockParty2 {
-					continue
-				}
+func (s *Suite) testRelationshipFilterByTypeAndBoth(expected map[string][]string, types []*RelationshipType, parties []*Party) {
+	for _, relationshipType := range types {
+		rType := relationshipType.ID
+		for _, party1 := range parties {
+			for _, party2 := range parties {
 				list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-					FirstPartyID:  mockParty1,
-					SecondPartyID: mockParty2,
+					RelationshipTypeID: rType,
+					FirstPartyID:       party1.ID,
+					SecondPartyID:      party2.ID,
 				})
-				if !assert.NoError(t, err) {
-					return
+				if !assert.NoError(s.T(), err) {
+					s.T().FailNow()
 				}
-				key := mockParty1 + mockParty2
+				key := rType + party1.ID + party2.ID
 				// map entry and returned list should have the same length
-				assert.Len(t, byParties[key], len(list.Items))
+				assert.Len(s.T(), expected[key], len(list.Items))
 				// map entry should contain same items as list
 				for _, l := range list.Items {
-					assert.Contains(t, byParties[key], l)
+					assert.Contains(s.T(), expected[key], l.ID)
 				}
 			}
 		}
-	})
-}
-
-func (s *Suite) filter_by_RelTypeID_and_EitherParty() bool {
-	return s.T().Run("Filter by RelTypeID and EitherParty", func(t *testing.T) {
-		for _, mockRelTypeID := range mockRelationshipTypeIDs {
-			for _, mockParty := range mockParties {
-				list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-					RelationshipTypeID: mockRelTypeID,
-					EitherPartyID:      mockParty,
-				})
-				if !assert.NoError(t, err) {
-					return
-				}
-				// map entry and returned list should have the same length
-				assert.Len(t, byRelTypeIDAndEitherParty[mockRelTypeID+mockParty], len(list.Items))
-				// map entry should contain same items as list
-				for _, l := range list.Items {
-					assert.Contains(t, byRelTypeIDAndEitherParty[mockRelTypeID+mockParty], l)
-				}
-			}
-		}
-	})
-}
-
-func (s *Suite) filter_by_EitherParty() bool {
-	return s.T().Run("Filter by EitherParty", func(t *testing.T) {
-		for _, mockParty := range mockParties {
-			list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-				EitherPartyID: mockParty,
-			})
-			if !assert.NoError(t, err) {
-				return
-			}
-			// map entry and returned list should have the same length
-			assert.Len(t, byEitherParty[mockParty], len(list.Items))
-			// map entry should contain same items as list
-			for _, l := range list.Items {
-				assert.Contains(t, byEitherParty[mockParty], l)
-			}
-		}
-	})
-}
-
-func (s *Suite) filter_by_SecondPartyID() bool {
-	return s.T().Run("Filter by SecondPartyID", func(t *testing.T) {
-		for _, mockParty := range mockParties {
-			list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-				SecondPartyID: mockParty,
-			})
-			if !assert.NoError(t, err) {
-				return
-			}
-			// map entry and returned list should have the same length
-			assert.Len(t, bySecondParty[mockParty], len(list.Items))
-			// map entry should contain same items as list
-			for _, l := range list.Items {
-				assert.Contains(t, bySecondParty[mockParty], l)
-			}
-		}
-	})
-}
-
-func (s *Suite) filter_by_firstPartyID() bool {
-	return s.T().Run("Filter by FirstPartyID", func(t *testing.T) {
-		for _, mockParty := range mockParties {
-			list, err := s.client.Relationships().List(s.ctx, RelationshipListOptions{
-				FirstPartyID: mockParty,
-			})
-			if !assert.NoError(t, err) {
-				return
-			}
-			// map entry and returned list should have the same length
-			assert.Len(t, byFirstParty[mockParty], len(list.Items))
-			// map entry should contain same items as list
-			for _, l := range list.Items {
-				assert.Contains(t, byFirstParty[mockParty], l)
-			}
-		}
-	})
+	}
 }

--- a/api/pkg/apps/iam/relationshiptype_get.go
+++ b/api/pkg/apps/iam/relationshiptype_get.go
@@ -4,19 +4,19 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetRelationshipType(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getRelationshipType(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	ret, err := s.RelationshipTypeStore.Get(ctx, id)
+	ret, err := s.relationshipTypeStore.Get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/relationshiptype_list.go
+++ b/api/pkg/apps/iam/relationshiptype_list.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListRelationshipTypes(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listRelationshipTypes(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	listOptions := &RelationshipTypeListOptions{}
 	if err := listOptions.UnmarshalQueryParameters(req.URL.Query()); err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	ret, err := s.RelationshipTypeStore.List(ctx, *listOptions)
+	ret, err := s.relationshipTypeStore.List(ctx, *listOptions)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/relationshiptype_post.go
+++ b/api/pkg/apps/iam/relationshiptype_post.go
@@ -5,22 +5,22 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostRelationshipType(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postRelationshipType(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var payload RelationshipType
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	p := &payload
 	p.ID = uuid.NewV4().String()
 
-	if err := s.RelationshipTypeStore.Create(ctx, p); err != nil {
-		s.Error(w, err)
+	if err := s.relationshipTypeStore.Create(ctx, p); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, p)
+	s.json(w, http.StatusOK, p)
 }

--- a/api/pkg/apps/iam/relationshiptype_put.go
+++ b/api/pkg/apps/iam/relationshiptype_put.go
@@ -4,23 +4,23 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutRelationshipType(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putRelationshipType(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
 	var payload RelationshipType
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	r, err := s.RelationshipTypeStore.Get(ctx, id)
+	r, err := s.relationshipTypeStore.Get(ctx, id)
 	if err != nil {
-		s.Error(w, err)
+		s.error(w, err)
 		return
 	}
 
@@ -30,10 +30,10 @@ func (s *Server) PutRelationshipType(w http.ResponseWriter, req *http.Request) {
 	r.Rules = payload.Rules
 	r.IsDirectional = payload.IsDirectional
 
-	if err := s.RelationshipTypeStore.Update(ctx, r); err != nil {
-		s.Error(w, err)
+	if err := s.relationshipTypeStore.Update(ctx, r); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, r)
+	s.json(w, http.StatusOK, r)
 }

--- a/api/pkg/apps/iam/relationshiptype_store.go
+++ b/api/pkg/apps/iam/relationshiptype_store.go
@@ -11,7 +11,7 @@ type RelationshipTypeStore struct {
 	collection *mongo.Collection
 }
 
-func NewRelationshipTypeStore(ctx context.Context, mongoClient *mongo.Client, database string) (*RelationshipTypeStore, error) {
+func newRelationshipTypeStore(ctx context.Context, mongoClient *mongo.Client, database string) (*RelationshipTypeStore, error) {
 	store := &RelationshipTypeStore{
 		collection: mongoClient.Database(database).Collection("relationshipTypes"),
 	}

--- a/api/pkg/apps/iam/relationshiptype_test.go
+++ b/api/pkg/apps/iam/relationshiptype_test.go
@@ -1,13 +1,14 @@
 // +build integration
 
-package iam
+package iam_test
 
 import (
+	. "github.com/nrc-no/core/pkg/apps/iam"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func (s *Suite) TestRelationShipTypeCRUD() {
+func (s *Suite) TestRelationshipType() {
 	// CREATE relationship type
 	mock := "create"
 	created, err := s.client.RelationshipTypes().Create(s.ctx, &RelationshipType{
@@ -83,10 +84,10 @@ func (s *Suite) TestRelationShipTypeCRUD() {
 	assert.Contains(s.T(), list.Items, get)
 }
 
-// TestRelationshipTypeList tests that we can effectively filter relationship types by
+// TestRelationshipTypeListFilter tests that we can effectively filter relationship types by
 // - PartyType = IndividualPartyType
 // - PartyType = HouseholdPartyType
-func (s *Suite) TestRelationshipTypeList() {
+func (s *Suite) TestRelationshipTypeListFilter() {
 
 	s.T().Run("test filter by IndividualPartyType", func(t *testing.T) {
 		// retrieve list of RelationshipTypes with the IndividualPartyType rule

--- a/api/pkg/apps/iam/server.go
+++ b/api/pkg/apps/iam/server.go
@@ -16,42 +16,42 @@ import (
 type Server struct {
 	environment           string
 	router                *mux.Router
-	AttributeStore        *AttributeStore
-	PartyStore            *PartyStore
-	PartyTypeStore        *PartyTypeStore
-	RelationshipStore     *RelationshipStore
-	RelationshipTypeStore *RelationshipTypeStore
-	IndividualStore       *IndividualStore
-	TeamStore             *TeamStore
-	MembershipStore       *MembershipStore
-	HydraAdmin            admin.ClientService
+	attributeStore        *AttributeStore
+	partyStore            *PartyStore
+	partyTypeStore        *PartyTypeStore
+	relationshipStore     *RelationshipStore
+	relationshipTypeStore *RelationshipTypeStore
+	individualStore       *IndividualStore
+	teamStore             *TeamStore
+	membershipStore       *MembershipStore
+	hydraAdmin            admin.ClientService
 	mongoClient           *mongo.Client
-	HydraHTTPClient       *http.Client
+	hydraHTTPClient       *http.Client
 }
 
 func NewServer(ctx context.Context, o *server.GenericServerOptions) (*Server, error) {
 
-	relationshipStore, err := NewRelationshipStore(ctx, o.MongoClient, o.MongoDatabase)
+	relationshipStore, err := newRelationshipStore(ctx, o.MongoClient, o.MongoDatabase)
 	if err != nil {
 		return nil, err
 	}
 
-	partyStore, err := NewPartyStore(ctx, o.MongoClient, o.MongoDatabase)
+	partyStore, err := newPartyStore(ctx, o.MongoClient, o.MongoDatabase)
 	if err != nil {
 		return nil, err
 	}
 
-	attributeStore, err := NewAttributeStore(ctx, o.MongoClient, o.MongoDatabase)
+	attributeStore, err := newAttributeStore(ctx, o.MongoClient, o.MongoDatabase)
 	if err != nil {
 		return nil, err
 	}
 
-	partyTypeStore, err := NewPartyTypeStore(ctx, o.MongoClient, o.MongoDatabase)
+	partyTypeStore, err := newPartyTypeStore(ctx, o.MongoClient, o.MongoDatabase)
 	if err != nil {
 		return nil, err
 	}
 
-	relationshipTypeStore, err := NewRelationshipTypeStore(ctx, o.MongoClient, o.MongoDatabase)
+	relationshipTypeStore, err := newRelationshipTypeStore(ctx, o.MongoClient, o.MongoDatabase)
 	if err != nil {
 		return nil, err
 	}
@@ -64,61 +64,61 @@ func NewServer(ctx context.Context, o *server.GenericServerOptions) (*Server, er
 	srv := &Server{
 		environment:           o.Environment,
 		mongoClient:           o.MongoClient,
-		AttributeStore:        attributeStore,
-		PartyStore:            partyStore,
-		PartyTypeStore:        partyTypeStore,
-		RelationshipStore:     relationshipStore,
-		RelationshipTypeStore: relationshipTypeStore,
-		IndividualStore:       NewIndividualStore(o.MongoClient, o.MongoDatabase),
-		TeamStore:             NewTeamStore(partyStore),
-		MembershipStore:       NewMembershipStore(relationshipStore),
-		HydraAdmin:            hydraAdmin,
-		HydraHTTPClient:       o.HydraHTTPClient,
+		attributeStore:        attributeStore,
+		partyStore:            partyStore,
+		partyTypeStore:        partyTypeStore,
+		relationshipStore:     relationshipStore,
+		relationshipTypeStore: relationshipTypeStore,
+		individualStore:       NewIndividualStore(o.MongoClient, o.MongoDatabase),
+		teamStore:             NewTeamStore(partyStore),
+		membershipStore:       NewMembershipStore(relationshipStore),
+		hydraAdmin:            hydraAdmin,
+		hydraHTTPClient:       o.HydraHTTPClient,
 	}
 
 	router := mux.NewRouter()
-	router.Use(srv.WithAuth())
+	router.Use(srv.withAuth())
 
-	router.Path(server.AttributesEndpoint).Methods("GET").HandlerFunc(srv.ListAttributes)
-	router.Path(server.AttributesEndpoint).Methods("POST").HandlerFunc(srv.PostAttribute)
-	router.Path(path.Join(server.AttributesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetAttribute)
-	router.Path(path.Join(server.AttributesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutAttribute)
+	router.Path(server.AttributesEndpoint).Methods("GET").HandlerFunc(srv.listAttributes)
+	router.Path(server.AttributesEndpoint).Methods("POST").HandlerFunc(srv.postAttributes)
+	router.Path(path.Join(server.AttributesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getAttribute)
+	router.Path(path.Join(server.AttributesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putAttribute)
 
-	router.Path(server.IndividualsEndpoint).Methods("GET").HandlerFunc(srv.ListIndividuals)
-	router.Path(server.IndividualsEndpoint).Methods("POST").HandlerFunc(srv.PostIndividual)
-	router.Path(path.Join(server.IndividualsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetIndividual)
-	router.Path(path.Join(server.IndividualsEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutIndividual)
+	router.Path(server.IndividualsEndpoint).Methods("GET").HandlerFunc(srv.listIndividuals)
+	router.Path(server.IndividualsEndpoint).Methods("POST").HandlerFunc(srv.postIndividual)
+	router.Path(path.Join(server.IndividualsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getIndividual)
+	router.Path(path.Join(server.IndividualsEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putIndividual)
 
-	router.Path(server.MembershipsEndpoint).Methods("GET").HandlerFunc(srv.ListMemberships)
-	router.Path(server.MembershipsEndpoint).Methods("POST").HandlerFunc(srv.PostMembership)
-	router.Path(path.Join(server.MembershipsEndpoint, "{v1}")).Methods("GET").HandlerFunc(srv.GetMembership)
+	router.Path(server.MembershipsEndpoint).Methods("GET").HandlerFunc(srv.listMemberships)
+	router.Path(server.MembershipsEndpoint).Methods("POST").HandlerFunc(srv.postMembership)
+	router.Path(path.Join(server.MembershipsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getMembership)
 
-	router.Path(server.PartiesEndpoint).Methods("GET").HandlerFunc(srv.ListParties)
-	router.Path(server.PartiesEndpoint).Methods("POST").HandlerFunc(srv.PostParty)
-	router.Path(path.Join(server.PartiesEndpoint, "/search")).Methods("POST").HandlerFunc(srv.SearchParties)
-	router.Path(path.Join(server.PartiesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetParty)
-	router.Path(path.Join(server.PartiesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutParty)
+	router.Path(server.PartiesEndpoint).Methods("GET").HandlerFunc(srv.listParties)
+	router.Path(server.PartiesEndpoint).Methods("POST").HandlerFunc(srv.postParty)
+	router.Path(path.Join(server.PartiesEndpoint, "/search")).Methods("POST").HandlerFunc(srv.searchParties)
+	router.Path(path.Join(server.PartiesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getParty)
+	router.Path(path.Join(server.PartiesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putParty)
 
-	router.Path(server.PartyTypesEndpoint).Methods("GET").HandlerFunc(srv.ListPartyTypes)
-	router.Path(server.PartyTypesEndpoint).Methods("POST").HandlerFunc(srv.PostPartyType)
-	router.Path(path.Join(server.PartyTypesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetPartyType)
-	router.Path(path.Join(server.PartyTypesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutPartyType)
+	router.Path(server.PartyTypesEndpoint).Methods("GET").HandlerFunc(srv.listPartyTypes)
+	router.Path(server.PartyTypesEndpoint).Methods("POST").HandlerFunc(srv.postPartyType)
+	router.Path(path.Join(server.PartyTypesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getPartyType)
+	router.Path(path.Join(server.PartyTypesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putPartyType)
 
-	router.Path(server.RelationshipsEndpoint).Methods("GET").HandlerFunc(srv.ListRelationships)
-	router.Path(server.RelationshipsEndpoint).Methods("POST").HandlerFunc(srv.PostRelationship)
-	router.Path(path.Join(server.RelationshipsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetRelationship)
-	router.Path(path.Join(server.RelationshipsEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutRelationship)
-	router.Path(path.Join(server.RelationshipsEndpoint, "{id}")).Methods("DELETE").HandlerFunc(srv.DeleteRelationship)
+	router.Path(server.RelationshipsEndpoint).Methods("GET").HandlerFunc(srv.listRelationships)
+	router.Path(server.RelationshipsEndpoint).Methods("POST").HandlerFunc(srv.postRelationship)
+	router.Path(path.Join(server.RelationshipsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getRelationship)
+	router.Path(path.Join(server.RelationshipsEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putRelationship)
+	router.Path(path.Join(server.RelationshipsEndpoint, "{id}")).Methods("DELETE").HandlerFunc(srv.deleteRelationship)
 
-	router.Path(server.RelationshipTypesEndpoint).Methods("GET").HandlerFunc(srv.ListRelationshipTypes)
-	router.Path(server.RelationshipTypesEndpoint).Methods("POST").HandlerFunc(srv.PostRelationshipType)
-	router.Path(path.Join(server.RelationshipTypesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetRelationshipType)
-	router.Path(path.Join(server.RelationshipTypesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutRelationshipType)
+	router.Path(server.RelationshipTypesEndpoint).Methods("GET").HandlerFunc(srv.listRelationshipTypes)
+	router.Path(server.RelationshipTypesEndpoint).Methods("POST").HandlerFunc(srv.postRelationshipType)
+	router.Path(path.Join(server.RelationshipTypesEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getRelationshipType)
+	router.Path(path.Join(server.RelationshipTypesEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putRelationshipType)
 
-	router.Path(server.TeamsEndpoint).Methods("GET").HandlerFunc(srv.ListTeams)
-	router.Path(server.TeamsEndpoint).Methods("POST").HandlerFunc(srv.PostTeam)
-	router.Path(path.Join(server.TeamsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.GetTeam)
-	router.Path(path.Join(server.TeamsEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.PutTeam)
+	router.Path(server.TeamsEndpoint).Methods("GET").HandlerFunc(srv.listTeams)
+	router.Path(server.TeamsEndpoint).Methods("POST").HandlerFunc(srv.postTeam)
+	router.Path(path.Join(server.TeamsEndpoint, "{id}")).Methods("GET").HandlerFunc(srv.getTeam)
+	router.Path(path.Join(server.TeamsEndpoint, "{id}")).Methods("PUT").HandlerFunc(srv.putTeam)
 
 	srv.router = router
 
@@ -129,7 +129,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.router.ServeHTTP(w, req)
 }
 
-func (s *Server) JSON(w http.ResponseWriter, status int, data interface{}) {
+func (s *Server) json(w http.ResponseWriter, status int, data interface{}) {
 	responseBytes, err := json.Marshal(data)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -143,7 +143,7 @@ func (s *Server) JSON(w http.ResponseWriter, status int, data interface{}) {
 	}
 }
 
-func (s *Server) GetPathParam(param string, w http.ResponseWriter, req *http.Request, into *string) bool {
+func (s *Server) getPathParam(param string, w http.ResponseWriter, req *http.Request, into *string) bool {
 	id, ok := mux.Vars(req)[param]
 	if !ok || len(id) == 0 {
 		err := fmt.Errorf("path parameter '%s' not found in path", param)
@@ -154,11 +154,11 @@ func (s *Server) GetPathParam(param string, w http.ResponseWriter, req *http.Req
 	return true
 }
 
-func (s *Server) Error(w http.ResponseWriter, err error) {
+func (s *Server) error(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
 
-func (s *Server) Bind(req *http.Request, into interface{}) error {
+func (s *Server) bind(req *http.Request, into interface{}) error {
 	bodyBytes, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		return err
@@ -168,5 +168,15 @@ func (s *Server) Bind(req *http.Request, into interface{}) error {
 		return err
 	}
 
+	return nil
+}
+
+func (s *Server) ResetDB(ctx context.Context, databaseName string) error {
+	if err := s.mongoClient.Database(databaseName).Drop(ctx); err != nil {
+		return err
+	}
+	if err := s.Init(ctx); err != nil {
+		return err
+	}
 	return nil
 }

--- a/api/pkg/apps/iam/team_get.go
+++ b/api/pkg/apps/iam/team_get.go
@@ -4,20 +4,20 @@ import (
 	"net/http"
 )
 
-func (s *Server) GetTeam(w http.ResponseWriter, req *http.Request) {
+func (s *Server) getTeam(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
-	ret, err := s.TeamStore.Get(ctx, id)
+	ret, err := s.teamStore.Get(ctx, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 
 }

--- a/api/pkg/apps/iam/team_list.go
+++ b/api/pkg/apps/iam/team_list.go
@@ -4,14 +4,14 @@ import (
 	"net/http"
 )
 
-func (s *Server) ListTeams(w http.ResponseWriter, req *http.Request) {
+func (s *Server) listTeams(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
-	ret, err := s.TeamStore.List(ctx)
+	ret, err := s.teamStore.List(ctx)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, ret)
+	s.json(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/iam/team_post.go
+++ b/api/pkg/apps/iam/team_post.go
@@ -5,22 +5,22 @@ import (
 	"net/http"
 )
 
-func (s *Server) PostTeam(w http.ResponseWriter, req *http.Request) {
+func (s *Server) postTeam(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 
 	var payload Team
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
 	team := &payload
 	team.ID = uuid.NewV4().String()
 
-	if err := s.TeamStore.Create(ctx, team); err != nil {
+	if err := s.teamStore.Create(ctx, team); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, team)
+	s.json(w, http.StatusOK, team)
 }

--- a/api/pkg/apps/iam/team_put.go
+++ b/api/pkg/apps/iam/team_put.go
@@ -4,21 +4,21 @@ import (
 	"net/http"
 )
 
-func (s *Server) PutTeam(w http.ResponseWriter, req *http.Request) {
+func (s *Server) putTeam(w http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	var id string
 
-	if !s.GetPathParam("id", w, req, &id) {
+	if !s.getPathParam("id", w, req, &id) {
 		return
 	}
 
 	var payload Team
-	if err := s.Bind(req, &payload); err != nil {
-		s.Error(w, err)
+	if err := s.bind(req, &payload); err != nil {
+		s.error(w, err)
 		return
 	}
 
-	r, err := s.TeamStore.Get(ctx, id)
+	r, err := s.teamStore.Get(ctx, id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -27,11 +27,11 @@ func (s *Server) PutTeam(w http.ResponseWriter, req *http.Request) {
 	r.ID = id
 	r.Name = payload.Name
 
-	if err := s.TeamStore.Update(ctx, r); err != nil {
+	if err := s.teamStore.Update(ctx, r); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	s.JSON(w, http.StatusOK, r)
+	s.json(w, http.StatusOK, r)
 
 }

--- a/api/pkg/apps/iam/team_store.go
+++ b/api/pkg/apps/iam/team_store.go
@@ -17,7 +17,7 @@ func NewTeamStore(partyStore *PartyStore) *TeamStore {
 
 func (s *TeamStore) Get(ctx context.Context, id string) (*Team, error) {
 
-	p, err := s.partyStore.Get(ctx, id)
+	p, err := s.partyStore.get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func MapTeamToParty(team *Team) *Party {
 }
 
 func (s *TeamStore) List(ctx context.Context) (*TeamList, error) {
-	ps, err := s.partyStore.List(ctx, PartySearchOptions{
+	ps, err := s.partyStore.list(ctx, PartySearchOptions{
 		PartyTypeIDs: []string{TeamPartyType.ID},
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func (s *TeamStore) List(ctx context.Context) (*TeamList, error) {
 
 func (s *TeamStore) Update(ctx context.Context, team *Team) error {
 	party := MapTeamToParty(team)
-	if err := s.partyStore.Update(ctx, party); err != nil {
+	if err := s.partyStore.update(ctx, party); err != nil {
 		return err
 	}
 	return nil
@@ -77,7 +77,7 @@ func (s *TeamStore) Update(ctx context.Context, team *Team) error {
 
 func (s *TeamStore) Create(ctx context.Context, team *Team) error {
 	party := MapTeamToParty(team)
-	if err := s.partyStore.Create(ctx, party); err != nil {
+	if err := s.partyStore.create(ctx, party); err != nil {
 		return err
 	}
 	return nil

--- a/api/pkg/apps/iam/team_test.go
+++ b/api/pkg/apps/iam/team_test.go
@@ -1,21 +1,22 @@
 // +build integration
 
-package iam
+package iam_test
 
-import (
-	uuid "github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
-)
+import "github.com/stretchr/testify/assert"
+import . "github.com/nrc-no/core/pkg/apps/iam"
 
-func (s *Suite) TestTeamCrud() {
+func (s *Suite) TestTeam() {
+	s.Run("API", func() { s.testTeamAPI() })
+}
 
+func (s *Suite) testTeamAPI() {
 	// Create team
-	name := uuid.NewV4().String()
+	name := newUUID()
 	created, err := s.client.Teams().Create(s.ctx, &Team{
 		Name: name,
 	})
 	if !assert.NoError(s.T(), err) {
-		return
+		s.T().FailNow()
 	}
 	assert.Equal(s.T(), name, created.Name)
 	assert.NotEmpty(s.T(), created.ID)
@@ -23,7 +24,7 @@ func (s *Suite) TestTeamCrud() {
 	// Get team
 	get, err := s.client.Teams().Get(s.ctx, created.ID)
 	if !assert.NoError(s.T(), err) {
-		return
+		s.T().FailNow()
 	}
 	if !assert.Equal(s.T(), get, created) {
 		return
@@ -32,8 +33,7 @@ func (s *Suite) TestTeamCrud() {
 	// List teams
 	list, err := s.client.Teams().List(s.ctx, TeamListOptions{})
 	if !assert.NoError(s.T(), err) {
-		return
+		s.T().FailNow()
 	}
 	assert.Contains(s.T(), list.Items, get)
-
 }

--- a/api/pkg/apps/iam/test-coverage-report.sh
+++ b/api/pkg/apps/iam/test-coverage-report.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+"${GOROOT}"/bin/go test -coverprofile=coverage.out --tags=integration
+"${GOROOT}"/bin/go tool -func=coverage.out
+"${GOROOT}"/bin/go tool cover -html=coverage.out

--- a/api/pkg/server/server.go
+++ b/api/pkg/server/server.go
@@ -5,14 +5,14 @@ import (
 	"github.com/nrc-no/core/pkg/apps/cms"
 	"github.com/nrc-no/core/pkg/apps/iam"
 	"github.com/nrc-no/core/pkg/apps/login"
-	webapp2 "github.com/nrc-no/core/pkg/apps/webapp"
+	"github.com/nrc-no/core/pkg/apps/webapp"
 	"github.com/ory/hydra-client-go/client"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Server struct {
 	MongoClient       *mongo.Client
-	WebAppServer      *webapp2.Server
+	WebAppServer      *webapp.Server
 	HydraPublicClient *client.OryHydra
 	HydraAdminClient  *client.OryHydra
 	Router            *mux.Router

--- a/e2e/.idea/e2e.iml
+++ b/e2e/.idea/e2e.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,3 +1,3 @@
 {
-  "baseUrl": "http://localhost:9000"
+  "baseUrl": "https://localhost:9000"
 }


### PR DESCRIPTION
All tests passing
TODO: Party Search test
TODO: cms API tests

About the migration of internal methods from public to private. While fiddling with test coverage, I was under the mistaken impression that only public methods appeared in the report, so I flipped all the methods that weren't part of the public API. Turns out the coverage report checks internals too, which makes sense.
In any case, given `iam`'s current package structure, I think the change is pertinent anyway.