### PR TITLE
COR-113: User cannot login after setting credential

### DIFF
--- a/api/pkg/apps/login/credentials_post.go
+++ b/api/pkg/apps/login/credentials_post.go
@@ -1,0 +1,26 @@
+package login
+
+import (
+	"net/http"
+)
+
+func (s *Server) PostCredentials(w http.ResponseWriter, req *http.Request) {
+	saltedHash, err := HashAndSalt(s.BCryptCost, []byte(req.Form.Get("plaintextPassword")))
+	if err != nil {
+		s.Error(w, err)
+		return
+	}
+
+	var newCredential = Credential{
+		PartyID: req.Form.Get("partyId"),
+		Hash:    saltedHash,
+	}
+
+	_, err = s.Collection.InsertOne(req.Context(), newCredential)
+	if err != nil {
+		s.Error(w, err)
+		return
+	}
+
+	s.json(w, http.StatusOK, newCredential)
+}

--- a/api/pkg/apps/login/credentials_post.go
+++ b/api/pkg/apps/login/credentials_post.go
@@ -5,14 +5,20 @@ import (
 )
 
 func (s *Server) PostCredentials(w http.ResponseWriter, req *http.Request) {
-	saltedHash, err := HashAndSalt(s.BCryptCost, []byte(req.Form.Get("plaintextPassword")))
+	var payload SetCredentialPayload
+	if err := s.Bind(req, &payload); err != nil {
+		s.Error(w, err)
+		return
+	}
+
+	saltedHash, err := HashAndSalt(s.BCryptCost, []byte(payload.PlaintextPassword))
 	if err != nil {
 		s.Error(w, err)
 		return
 	}
 
 	var newCredential = Credential{
-		PartyID: req.Form.Get("partyId"),
+		PartyID: payload.PartyID,
 		Hash:    saltedHash,
 	}
 

--- a/api/pkg/apps/login/credentials_post.go
+++ b/api/pkg/apps/login/credentials_post.go
@@ -34,34 +34,18 @@ func (s *Server) PostCredentials(w http.ResponseWriter, req *http.Request) {
 		credentials = append(credentials, &c)
 	}
 
-	saltedHash, err := HashAndSalt(s.BCryptCost, []byte(payload.PlaintextPassword))
-	if err != nil {
-		s.Error(w, err)
-		return
-	}
-
-	var returnValue Credential
-
 	// no credentials found, need to create new
 	if len(credentials) == 0 {
-		var newCredential = Credential{
-			PartyID: payload.PartyID,
-			Hash:    saltedHash,
-		}
-
-		_, err = s.Collection.InsertOne(ctx, newCredential)
+		err = s.CreatePassword(ctx, payload.PartyID, payload.PlaintextPassword)
 		if err != nil {
 			s.Error(w, err)
 			return
 		}
-
-		returnValue = newCredential
 	}
 
 	// existing credential found, updating
 	if len(credentials) == 1 {
 		err = s.SetPassword(ctx, payload.PartyID, payload.PlaintextPassword)
-
 		if err != nil {
 			s.Error(w, err)
 			return
@@ -74,5 +58,6 @@ func (s *Server) PostCredentials(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	s.json(w, http.StatusOK, returnValue)
+	var i interface{}
+	s.json(w, http.StatusOK, i)
 }

--- a/api/pkg/apps/login/credentials_post.go
+++ b/api/pkg/apps/login/credentials_post.go
@@ -1,14 +1,37 @@
 package login
 
 import (
+	"errors"
+	"go.mongodb.org/mongo-driver/bson"
 	"net/http"
 )
 
 func (s *Server) PostCredentials(w http.ResponseWriter, req *http.Request) {
+	ctx := req.Context()
+
 	var payload SetCredentialPayload
 	if err := s.Bind(req, &payload); err != nil {
 		s.Error(w, err)
 		return
+	}
+
+	res, err := s.Collection.Find(ctx, bson.M{"partyId": payload.PartyID})
+	if err != nil {
+		s.Error(w, err)
+		return
+	}
+
+	var credentials []*Credential
+	for {
+		if !res.Next(ctx) {
+			break
+		}
+		var c Credential
+		if err := res.Decode(&c); err != nil {
+			s.Error(w, err)
+			return
+		}
+		credentials = append(credentials, &c)
 	}
 
 	saltedHash, err := HashAndSalt(s.BCryptCost, []byte(payload.PlaintextPassword))
@@ -17,16 +40,39 @@ func (s *Server) PostCredentials(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var newCredential = Credential{
-		PartyID: payload.PartyID,
-		Hash:    saltedHash,
+	var returnValue Credential
+
+	// no credentials found, need to create new
+	if len(credentials) == 0 {
+		var newCredential = Credential{
+			PartyID: payload.PartyID,
+			Hash:    saltedHash,
+		}
+
+		_, err = s.Collection.InsertOne(ctx, newCredential)
+		if err != nil {
+			s.Error(w, err)
+			return
+		}
+
+		returnValue = newCredential
 	}
 
-	_, err = s.Collection.InsertOne(req.Context(), newCredential)
-	if err != nil {
-		s.Error(w, err)
+	// existing credential found, updating
+	if len(credentials) == 1 {
+		err = s.SetPassword(ctx, payload.PartyID, payload.PlaintextPassword)
+
+		if err != nil {
+			s.Error(w, err)
+			return
+		}
+	}
+
+	// more than one credential found, error
+	if len(credentials) > 1 {
+		s.Error(w, errors.New("more than one credential found for user"))
 		return
 	}
 
-	s.json(w, http.StatusOK, newCredential)
+	s.json(w, http.StatusOK, returnValue)
 }

--- a/api/pkg/apps/login/passwords.go
+++ b/api/pkg/apps/login/passwords.go
@@ -69,6 +69,26 @@ func (s *Server) SetPassword(ctx context.Context, partyID string, password strin
 	return nil
 }
 
+// CreatePassword will create a new credential for the Party
+func (s *Server) CreatePassword(ctx context.Context, partyID string, password string) error {
+	saltedHash, err := HashAndSalt(s.BCryptCost, []byte(password))
+	if err != nil {
+		return err
+	}
+
+	var newCredential = Credential{
+		PartyID: partyID,
+		Hash:    saltedHash,
+	}
+
+	_, err = s.Collection.InsertOne(ctx, newCredential)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // HashAndSalt uses bcrypt algorithm to compute a salt + hash of a password
 // Used to mitigate bruteforce attacks, rainbow tables, etc.
 func HashAndSalt(cost int, pwd []byte) (string, error) {

--- a/api/pkg/apps/login/server.go
+++ b/api/pkg/apps/login/server.go
@@ -64,7 +64,7 @@ func NewServer(ctx context.Context, o *ServerOptions) (*Server, error) {
 	router.Path("/auth/consent").Methods("POST").HandlerFunc(srv.PostConsent)
 	router.Path("/apis/login/v1/credentials").
 		Methods("POST").
-		Handler(srv.WithAuth()(http.HandlerFunc(srv.PostLoginForm)))
+		Handler(srv.WithAuth()(http.HandlerFunc(srv.PostCredentials)))
 
 	srv.router = router
 
@@ -78,6 +78,10 @@ func NewServer(ctx context.Context, o *ServerOptions) (*Server, error) {
 
 	return srv, nil
 
+}
+
+func (s *Server) json(w http.ResponseWriter, status int, data interface{}) {
+	utils.JSONResponse(w, status, data)
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Diagnosed problem where user could not login after setting credentials:
- Null request was being sent to Hydra from app
- Null request happened because we did not store credential in MongoDB

To remedy:
1. Added a new method called PostCredential() which takes care of hashing, salting and storing the password in MongoDB

![Peek 2021-07-27 13-26](https://user-images.githubusercontent.com/15915453/127146334-ae630a4c-aba4-448f-9619-86d2400c5f17.gif)
