### PR TITLE
COR-177: add logic to prevent dropdown list getting hidden on click

### DIFF
--- a/api/pkg/apps/webapp/templates/head.gohtml
+++ b/api/pkg/apps/webapp/templates/head.gohtml
@@ -6,13 +6,13 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <!-- Bootstrap CSS -->
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/css/bootstrap.min.css" rel="stylesheet"
-              integrity="sha384-+0n0xVW2eSR5OomGNYDnhzAbDsOXxcvSN1TPprVMTNDbiYZCxYbOOl7+AMvyTG2x"
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
+              integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
               crossorigin="anonymous">
 
         <!-- JavaScript Bundle with Popper -->
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js"
-                integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4"
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+                integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
                 crossorigin="anonymous"></script>
         <!--Bootstrap Icons-->
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">

--- a/api/pkg/apps/webapp/templates/individual.gohtml
+++ b/api/pkg/apps/webapp/templates/individual.gohtml
@@ -74,13 +74,15 @@
                             </div>
                             <div class="form-floating mx-2 flex-grow-1 dropdown">
                                 <input type="text"
-                                       class="form-control dropdown-toggle"
+                                       class="form-control"
                                        name="partySelector"
                                        id="partySelector"
                                        data-testid="relatedParty"
-                                       data-bs-toggle="dropdown"
-                                       aria-expanded="false" />
-
+                                                                               data-bs-toggle="dropdown"
+                                                                               data-bs-auto-close="false"
+                                                                               aria-expanded="false"
+                                       autocomplete="off"
+                                />
                                 <ul class="dropdown-menu" id="partySelectorList" aria-labelledby="partySelector">
                                 </ul>
                                 <label for="partySelector" class="form-label">Related Party</label>
@@ -324,33 +326,28 @@
           addRelationship(relationshipType, party);
         };
 
-        // Prevent partySelector click bug
-        document.getElementById('partySelector').addEventListener('focusin', (event) => {
-          const partySelectorList = document.getElementById("partySelectorList");
-          if (partySelectorList.classList.contains("hide")) {
-            partySelectorList.classList.remove("hide");
+        // Override bootstrap dropdown events
+        const partySelector = document.querySelector('#partySelector')
+        const toggler = new bootstrap.Dropdown(partySelector);
+        document.querySelector('#partySelector').onclick = (event) => {
+          toggler.show();
+        };
+        // Hide dropdown on click outside
+        document.onclick = event => {
+          const partySelectorList = document.querySelector('#partySelectorList');
+          const shouldHidePartySelectorList = event.target.id !== 'partySelector' && partySelectorList.classList.contains('show');
+          if (shouldHidePartySelectorList) {
+            toggler.hide();
           }
-          if (!partySelectorList.classList.contains("show")) {
-            partySelectorList.classList.add("show");
-          }
-        });
-        document.getElementById('partySelector').addEventListener('focusout', (event) => {
-          const partySelectorList = document.getElementById("partySelectorList");
-          if (partySelectorList.classList.contains("show")) {
-            partySelectorList.classList.remove("show");
-          }
-          if (!partySelectorList.classList.contains("hide")) {
-            partySelectorList.classList.add("hide");
-          }
-        });
+        };
 
         // Add listener for party selector item click
-        Array.from(document.getElementsByClassName('partySelectorItem')).forEach(e => {
+        document.querySelectorAll('.partySelectorItem').forEach(e => {
           e.onclick = onPartyListItemClick;
         });
 
         // Add listener for party search box
-        document.getElementById('partySelector').oninput = (event) => {
+        partySelector.oninput = (event) => {
           partySearchSubject.next(event.target.value);
         };
 
@@ -386,7 +383,6 @@
               // No Parties Found...
               let newListItem = document.createElement('li');
               newListItem.classList.add('dropdown-item');
-              newListItem.onclick = onPartyListItemClick;
               let displayText = `No Parties Found`;
               newListItem.appendChild(
                 document.createTextNode(displayText)
@@ -404,7 +400,6 @@
           const list = document.getElementById('relationships-list');
           list.innerHTML = '';
           relationships.forEach((relationship, idx) => {
-            console.table(relationship)
             const li = document.createElement('li');
             li.className = 'list-group-item';
             const firstPartyName = parties.find(({ id }) => id === relationship.firstParty)?.name;

--- a/api/pkg/apps/webapp/templates/individual.gohtml
+++ b/api/pkg/apps/webapp/templates/individual.gohtml
@@ -78,9 +78,9 @@
                                        name="partySelector"
                                        id="partySelector"
                                        data-testid="relatedParty"
-                                                                               data-bs-toggle="dropdown"
-                                                                               data-bs-auto-close="false"
-                                                                               aria-expanded="false"
+                                       data-bs-toggle="dropdown"
+                                       data-bs-auto-close="false"
+                                       aria-expanded="false"
                                        autocomplete="off"
                                 />
                                 <ul class="dropdown-menu" id="partySelectorList" aria-labelledby="partySelector">
@@ -327,7 +327,7 @@
         };
 
         // Override bootstrap dropdown events
-        const partySelector = document.querySelector('#partySelector')
+        const partySelector = document.querySelector('#partySelector');
         const toggler = new bootstrap.Dropdown(partySelector);
         document.querySelector('#partySelector').onclick = (event) => {
           toggler.show();

--- a/api/pkg/apps/webapp/templates/individual.gohtml
+++ b/api/pkg/apps/webapp/templates/individual.gohtml
@@ -324,6 +324,26 @@
           addRelationship(relationshipType, party);
         };
 
+        // Prevent partySelector click bug
+        document.getElementById('partySelector').addEventListener('focusin', (event) => {
+          const partySelectorList = document.getElementById("partySelectorList");
+          if (partySelectorList.classList.contains("hide")) {
+            partySelectorList.classList.remove("hide");
+          }
+          if (!partySelectorList.classList.contains("show")) {
+            partySelectorList.classList.add("show");
+          }
+        });
+        document.getElementById('partySelector').addEventListener('focusout', (event) => {
+          const partySelectorList = document.getElementById("partySelectorList");
+          if (partySelectorList.classList.contains("show")) {
+            partySelectorList.classList.remove("show");
+          }
+          if (!partySelectorList.classList.contains("hide")) {
+            partySelectorList.classList.add("hide");
+          }
+        });
+
         // Add listener for party selector item click
         Array.from(document.getElementsByClassName('partySelectorItem')).forEach(e => {
           e.onclick = onPartyListItemClick;


### PR DESCRIPTION
The party selector list now no longer gets hidden when clicking on the focused input.

Please excuse the google autofill dropdown that gets rendered by Chrome over the dropdown in the demo:
![Peek 2021-08-02 13-46](https://user-images.githubusercontent.com/15915453/127857157-d76554cb-0b48-4d13-a39a-e342bb8915b1.gif)
