### PR TITLE
COR-181: Fix bug on case submission

### DIFF
--- a/api/pkg/apps/webapp/cases.go
+++ b/api/pkg/apps/webapp/cases.go
@@ -360,6 +360,16 @@ func (s *Server) PutOrPostCase(req *http.Request, w http.ResponseWriter, ctx con
 	if ok {
 		validationOnly = true
 	}
+
+	if kase.CaseTypeID == "" {
+		// we need to get the caseTypeId from the form data
+		kase.CaseTypeID = req.Form.Get("caseTypeId")
+		if kase.CaseTypeID == "" {
+			s.Error(w, fmt.Errorf("unable to detect case type id for new case"))
+			return
+		}
+	}
+
 	caseType, err := cmsClient.CaseTypes().Get(ctx, kase.CaseTypeID)
 	if err != nil {
 		s.Error(w, err)


### PR DESCRIPTION
- caseTypeId was sometimes a blank string when being used to retrieve the caseType in order to access the template needed to submit a case, this caused a nil template and thus an error
- added a check to ensure that caseTypeId is not a blank, if it is we try to get the caseTypeId from the submitted form and if that fails we return a specific error