### PR TITLE
Cor 192 fix dropdown template

### DIFF
--- a/api/pkg/apps/webapp/templates/dropdown.gohtml
+++ b/api/pkg/apps/webapp/templates/dropdown.gohtml
@@ -1,12 +1,8 @@
 {{define "dropdown"}}
-    {{$prefix := ""}}
-    {{if .Prefix}}
-        {{$prefix = .Prefix}}
-    {{end}}
     <div class="form-floating mb-3">
         <label class="mb-2 text-muted" style="font-weight: bold;" for="{{.Attributes.Name}}">{{.Attributes.Label}}</label>
         <select id="{{.Attributes.Name}}"
-                name="{{$prefix}}{{.Attributes.Name}}"
+                name="{{.Attributes.Name}}"
                 class="form-select {{if .Errors}}is-invalid{{end}}"
                 {{if .Attributes.Multiple}}multiple{{end}}
                 {{if .Validation.Required}}required{{end}}
@@ -19,7 +15,7 @@
                 <option value="{{$i}}"
                         {{range $v := $.Attributes.Value }}{{if eq $istr $v}}selected{{end}}{{end}}>{{.}}</option>
             {{end}}
-        <
+        </select>
         <div class="form-text">{{.Attributes.Description}}</div>
         {{template "validation_feedback" .}}
     </div>


### PR DESCRIPTION
Some leftover code wasn't removed from the dropdown template which was breaking it. Also the select tag was not closed.

Fixing this revealed a UX bug detailed in COR-193