### PR TITLE
COR-149: add registration status label to invididual list page

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -25,7 +25,7 @@
         <env name="PATH" value="$GoBinDirs$" />
       </envs>
     </TaskOptions>
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="run --disable=typecheck $FileDir$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/api/pkg/apps/webapp/individual_registration_controller.go
+++ b/api/pkg/apps/webapp/individual_registration_controller.go
@@ -10,20 +10,12 @@ import (
 
 func (s *Server) GetRegistrationController(w http.ResponseWriter, req *http.Request, individual *iam.Individual) (*registrationctrl.RegistrationController, error) {
 	var individualId string
-	if !s.GetPathParam("id", w, req, &individualId) {
-		return nil, fmt.Errorf("cannot find id in path")
+
+	if individual.ID == "new" || individual.ID == "" {
+		if !s.GetPathParam("id", w, req, &individualId) {
+			return nil, fmt.Errorf("cannot find id in path")
+		}
 	}
-
-	//iamClient, err := s.IAMClient(req)
-	//if err != nil {
-	//	return nil, err
-	//}
-
-	//i, err := iamClient.Individuals().Get(req.Context(), individualId)
-	//if err != nil {
-	//	return nil, err
-	//}
-
 	irh := NewIndividualRegistrationHandler(s, individual, req)
 
 	return registrationctrl.NewRegistrationController(irh, seeder.UgandaRegistrationFlow), nil

--- a/api/pkg/apps/webapp/templates/individuals.gohtml
+++ b/api/pkg/apps/webapp/templates/individuals.gohtml
@@ -1,17 +1,11 @@
 {{define "individual-row"}}
 
-    {{$gender := .FindAttributeValue "gender"}}
-    {{$age := .FindAge}}
-
     <a class="list-group-item font-monospace py-3 bg-quite-light"
        data-testid="individual"
-       href="/individuals/{{.ID}}">
-        {{.}}
+       href="/individuals/{{.Individual.ID}}">
+        {{.Individual}}
         <span class="d-block text-muted">
-            {{if $gender}}
-                {{if eq $gender "Male"}}M{{else if eq $gender "Female"}}F{{end}}
-            {{end}}
-            {{if $age}}{{$age}}{{end}}
+            Registration/Intake Step {{.RegistrationStatus.Label}}
         </span>
     </a>
 {{end}}
@@ -42,9 +36,10 @@
                         </div>
 
                     </div>
-                    {{ if .Individuals.Items}}
-                        {{ range .Individuals.Items }}
-                            {{template "individual-row" .}}
+
+                    {{ if .IndividualsWithStatuses}}
+                        {{ range .IndividualsWithStatuses }}
+                           {{template "individual-row" .}}
                         {{end}}
                     {{else}}
                         <div class='list-group-item disabled'>No individual found</div>


### PR DESCRIPTION
### Original ticket description:

As a { Project Manager | Enumerator | Triage Staff | Expert }
I want to see a beneficiaries status from the beneficiary list page
So that I can take pertinent actions for this beneficiary

Technical Description:

Beneficiary entry should show status. If status is an action, status should be a button pointing to form.

### Note

Since we did not yet go down the route of using actions, the later part of the requirement:

> If status is an action, status should be a button pointing to form.

Has not been implemented.