### PR TITLE
Cor 186 Prevent intake case editing until attribute are filled out

### DIFF
--- a/api/pkg/apps/cms/case_get.go
+++ b/api/pkg/apps/cms/case_get.go
@@ -18,7 +18,7 @@ func (s *Server) GetCase(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	if ret.Done {
-		ret.Template = ret.Template.MarkAsReadonly()
+		ret.Template.MarkAsReadonly()
 	}
 	s.JSON(w, http.StatusOK, ret)
 }

--- a/api/pkg/apps/cms/types.go
+++ b/api/pkg/apps/cms/types.go
@@ -80,12 +80,11 @@ type CaseTemplate struct {
 	FormElements []form.FormElement `json:"formElements" bson:"formElements"`
 }
 
-func (c *CaseTemplate) MarkAsReadonly() *CaseTemplate {
-	elems := []form.FormElement{}
+func (c *CaseTemplate) MarkAsReadonly() {
+	var elems []form.FormElement
 	for _, element := range c.FormElements {
-		e := element
-		e.Readonly = true
-		elems = append(elems, e)
+		element.Readonly = true
+		elems = append(elems, element)
 	}
-	return &CaseTemplate{elems}
+	c.FormElements = elems
 }

--- a/api/pkg/apps/webapp/individuals.go
+++ b/api/pkg/apps/webapp/individuals.go
@@ -324,6 +324,13 @@ func (s *Server) Individual(w http.ResponseWriter, req *http.Request) {
 		attribute.Attributes.Value = values
 	}
 
+	// mark cases readonly if needed
+	for _, kase := range []*cms.Case{individualAssessment, situationAnalysis} {
+		if kase != nil && (kase.Done || status.CurrentStage == -1) {
+			kase.Template.MarkAsReadonly()
+		}
+	}
+
 	if err := s.renderFactory.New(req, w).ExecuteTemplate(w, "individual", map[string]interface{}{
 		"IsNew":                     id == "new",
 		"Individual":                individual,


### PR DESCRIPTION
This turned out to be kind of redundant after COR-187 Registration Subpages because the intake case tab buttons remain disabled until the attributes stage has been completed. Nevertheless, the webapp's behavior now further ensures the Cases passed to the renderer are marked as readonly if the attributes haven't been filled out.