### PR TITLE
COR-235: Country specific attributes

### DIFF
--- a/api/pkg/apps/iam/attribute_store.go
+++ b/api/pkg/apps/iam/attribute_store.go
@@ -3,7 +3,6 @@ package iam
 import (
 	"context"
 	"github.com/nrc-no/core/pkg/utils"
-	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -50,7 +49,6 @@ func (s *AttributeStore) list(ctx context.Context, listOptions AttributeListOpti
 		}
 	}
 
-	logrus.Infof("CountryIDs len: %d", len(listOptions.CountryIDs))
 	if len(listOptions.CountryIDs) > 0 {
 		filter["countryId"] = bson.M{
 			"$in": listOptions.CountryIDs,

--- a/api/pkg/apps/iam/attribute_store.go
+++ b/api/pkg/apps/iam/attribute_store.go
@@ -3,6 +3,7 @@ package iam
 import (
 	"context"
 	"github.com/nrc-no/core/pkg/utils"
+	"github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -49,9 +50,10 @@ func (s *AttributeStore) list(ctx context.Context, listOptions AttributeListOpti
 		}
 	}
 
-	if len(listOptions.CountryIDs) == 1 {
+	logrus.Infof("CountryIDs len: %d", len(listOptions.CountryIDs))
+	if len(listOptions.CountryIDs) > 0 {
 		filter["countryId"] = bson.M{
-			"countryId": listOptions.CountryIDs[0],
+			"$in": listOptions.CountryIDs,
 		}
 	}
 

--- a/api/pkg/apps/iam/attribute_store.go
+++ b/api/pkg/apps/iam/attribute_store.go
@@ -49,6 +49,12 @@ func (s *AttributeStore) list(ctx context.Context, listOptions AttributeListOpti
 		}
 	}
 
+	if len(listOptions.CountryIDs) == 1 {
+		filter["countryId"] = bson.M{
+			"countryId": listOptions.CountryIDs[0],
+		}
+	}
+
 	collection, done, err := s.getCollection(ctx)
 	if err != nil {
 		return nil, err

--- a/api/pkg/apps/iam/client_interface.go
+++ b/api/pkg/apps/iam/client_interface.go
@@ -162,6 +162,7 @@ type RelationshipTypeClient interface {
 
 type AttributeListOptions struct {
 	PartyTypeIDs []string
+	CountryIDs []string
 }
 
 func (a *AttributeListOptions) MarshalQueryParameters() (url.Values, error) {

--- a/api/pkg/apps/iam/client_interface.go
+++ b/api/pkg/apps/iam/client_interface.go
@@ -170,12 +170,17 @@ func (a *AttributeListOptions) MarshalQueryParameters() (url.Values, error) {
 	for _, partyTypeID := range a.PartyTypeIDs {
 		ret.Add("partyTypeId", partyTypeID)
 	}
+	for _, countryID := range a.CountryIDs {
+		ret.Add("countryId", countryID)
+	}
 	return ret, nil
 }
 
 func (a *AttributeListOptions) UnmarshalQueryParameters(values url.Values) error {
 	partyTypeIDs := values["partyTypeId"]
+	countryIDs := values["countryId"]
 	a.PartyTypeIDs = append(a.PartyTypeIDs, partyTypeIDs...)
+	a.CountryIDs = append(a.CountryIDs, countryIDs...)
 	return nil
 }
 

--- a/api/pkg/apps/iam/static.go
+++ b/api/pkg/apps/iam/static.go
@@ -4,7 +4,7 @@ import "github.com/nrc-no/core/pkg/form"
 
 //Countries
 var GlobalCountry = Country{
-	ID:   "36790d84-0bea-437c-b26e-bae1bcd2d1bc",
+	ID:   "",
 	Name: "Global",
 }
 
@@ -17,6 +17,7 @@ var UgandaCountry = Country{
 var FullNameAttribute = Attribute{
 	ID:         "8514da51-aad5-4fb4-a797-8bcc0c969b27",
 	Name:       "fullName",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Text,
 	Attributes: form.FormElementAttributes{Name: "fullName"},
 	Validation: form.FormElementValidation{Required: true},
@@ -36,6 +37,7 @@ var FullNameAttribute = Attribute{
 var DisplayNameAttribute = Attribute{
 	ID:         "21079bbc-e04b-4fe8-897f-644d73af0d9e",
 	Name:       "displayName",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Text,
 	Attributes: form.FormElementAttributes{Name: "displayName"},
 	Validation: form.FormElementValidation{Required: true},
@@ -55,6 +57,7 @@ var DisplayNameAttribute = Attribute{
 var BirthDateAttribute = Attribute{
 	ID:         "87fe07d7-e6a7-4428-8086-3842b69f3665",
 	Name:       "birthDate",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Date,
 	Attributes: form.FormElementAttributes{Name: "birthDate"},
 	Validation: form.FormElementValidation{Required: true},
@@ -74,6 +77,7 @@ var BirthDateAttribute = Attribute{
 var EMailAttribute = Attribute{
 	ID:         "0ca7fa2b-982b-4fa5-85be-a6ebee8d4912",
 	Name:       "email",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Email,
 	Attributes: form.FormElementAttributes{Name: "email"},
 	Validation: form.FormElementValidation{Required: true},
@@ -266,6 +270,7 @@ var Admin5Attribute = Attribute{
 var InstructionOnMakingContactAttribute = Attribute{
 	ID:         "4d399cb3-6653-4a61-92eb-331f07e6c395",
 	Name:       "instructionOnMakingContact",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Textarea,
 	Attributes: form.FormElementAttributes{Name: "instructionOnMakingContact"},
 	Translations: []AttributeTranslation{
@@ -284,6 +289,7 @@ var InstructionOnMakingContactAttribute = Attribute{
 var CanInitiateContactAttribute = Attribute{
 	ID:   "7476fef0-d116-4b94-b981-ac647e16203d",
 	Name: "canInitiateContact",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "canInitiateContact",
@@ -307,6 +313,7 @@ var CanInitiateContactAttribute = Attribute{
 var DisplacementStatusAttribute = Attribute{
 	ID:   "d1d824b2-d163-43ff-bc0a-527bd86b79bb",
 	Name: "displacementStatus",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:    "displacementStatus",
@@ -329,6 +336,7 @@ var DisplacementStatusAttribute = Attribute{
 var GenderAttribute = Attribute{
 	ID:   "b43f630c-2eb6-4629-af89-44ded61f7f3e",
 	Name: "gender",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:    "gender",
@@ -357,6 +365,7 @@ var GenderAttribute = Attribute{
 var ConsentToNrcDataUseAttribute = Attribute{
 	ID:   "8463d701-f964-4454-b8b2-efc202e8007d",
 	Name: "consent_to_nrc_data_use",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "consent_to_nrc_data_use",
@@ -384,6 +393,7 @@ var ConsentToNrcDataUseAttribute = Attribute{
 var ConsentToNrcDataUseProofAttribute = Attribute{
 	ID:         "1ac8cf17-49f3-4281-b9c9-6fd6036229c2",
 	Name:       "consentToNrcDataUseProof",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.URL,
 	Attributes: form.FormElementAttributes{Name: "consentToNrcDataUseProof"},
 	Translations: []AttributeTranslation{
@@ -402,6 +412,7 @@ var ConsentToNrcDataUseProofAttribute = Attribute{
 var AnonymousAttribute = Attribute{
 	ID:   "0ab6fd31-fa0e-4d53-b236-94bce6f67d4b",
 	Name: "anonymous",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "anonymous",
@@ -425,6 +436,7 @@ var AnonymousAttribute = Attribute{
 var MinorAttribute = Attribute{
 	ID:   "24be4f47-ba00-405a-9bc5-c6fe58ecd80c",
 	Name: "minor",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "minor",
@@ -448,6 +460,7 @@ var MinorAttribute = Attribute{
 var ProtectionConcernsAttribute = Attribute{
 	ID:   "ae56b1fd-21f6-480a-9184-091a7093d8b8",
 	Name: "protectionConcerns",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "protectionConcerns",
@@ -471,6 +484,7 @@ var ProtectionConcernsAttribute = Attribute{
 var PhysicalImpairmentAttribute = Attribute{
 	ID:   "cb51b2e8-27da-4375-b85f-c5c107f5d2b4",
 	Name: "physicalImpairment",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "physicalImpairment",
@@ -494,6 +508,7 @@ var PhysicalImpairmentAttribute = Attribute{
 var PhysicalImpairmentIntensityAttribute = Attribute{
 	ID:   "98def70b-ee72-40eb-aed1-5a834bf8f579",
 	Name: "physicalImpairmentIntensity",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:    "physicalImpairmentIntensity",
@@ -515,6 +530,7 @@ var PhysicalImpairmentIntensityAttribute = Attribute{
 var SensoryImpairmentAttribute = Attribute{
 	ID:   "972c0d7f-8fa9-436d-95ab-6773070bc451",
 	Name: "sensoryImpairment",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "sensoryImpairment",
@@ -538,6 +554,7 @@ var SensoryImpairmentAttribute = Attribute{
 var SensoryImpairmentIntensityAttribute = Attribute{
 	ID:   "b1e6cfac-a8b9-4a0d-a5c7-f164fde99bcc",
 	Name: "sensoryImpairmentIntensity",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:    "sensoryImpairmentIntensity",
@@ -559,6 +576,7 @@ var SensoryImpairmentIntensityAttribute = Attribute{
 var MentalImpairmentAttribute = Attribute{
 	ID:   "41b7eb87-6488-47e3-a4b0-1422c039d0c7",
 	Name: "mentalImpairment",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name: "mentalImpairment",
@@ -582,6 +600,7 @@ var MentalImpairmentAttribute = Attribute{
 var MentalImpairmentIntensityAttribute = Attribute{
 	ID:   "9983188b-4f43-4cd5-a972-fde3a08f4810",
 	Name: "mentalImpairmentIntensity",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:    "mentalImpairmentIntensity",
@@ -603,6 +622,7 @@ var MentalImpairmentIntensityAttribute = Attribute{
 var NationalityAttribute = Attribute{
 	ID:   "76aab836-73a6-4a1e-9c17-04b8a4c25d8d",
 	Name: "nationality",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:     "nationality",
@@ -625,6 +645,7 @@ var NationalityAttribute = Attribute{
 var SpokenLanguagesAttribute = Attribute{
 	ID:         "d041cba5-9486-4390-bc2b-ec7fb03d67ff",
 	Name:       "spokenLanguages",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Text,
 	Attributes: form.FormElementAttributes{Name: "spokenLanguages"},
 	Translations: []AttributeTranslation{
@@ -643,6 +664,7 @@ var SpokenLanguagesAttribute = Attribute{
 var PreferredLanguageAttribute = Attribute{
 	ID:         "da27a6e8-abe3-48d5-bfd9-46033e476a09",
 	Name:       "preferredLanguage",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Text,
 	Attributes: form.FormElementAttributes{Name: "preferredLanguage"},
 	Translations: []AttributeTranslation{
@@ -665,6 +687,7 @@ var PreferredLanguageAttribute = Attribute{
 var PhysicalAddressAttribute = Attribute{
 	ID:         "ac2795e8-15a5-42a0-b11f-b9269ff2a309",
 	Name:       "physicalAddress",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Textarea,
 	Attributes: form.FormElementAttributes{Name: "physicalAddress"},
 	Translations: []AttributeTranslation{
@@ -684,6 +707,7 @@ var PhysicalAddressAttribute = Attribute{
 var PrimaryPhoneNumberAttribute = Attribute{
 	ID:         "8eae83a8-cbc7-4ab2-a21f-d57cb3bb29ff",
 	Name:       "primaryPhoneNumber",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Phone,
 	Attributes: form.FormElementAttributes{Name: "primaryPhoneNumber"},
 	Translations: []AttributeTranslation{
@@ -702,6 +726,7 @@ var PrimaryPhoneNumberAttribute = Attribute{
 var SecondaryPhoneNumberAttribute = Attribute{
 	ID:         "1f3016af-ab39-422a-beb8-904b68a1619e",
 	Name:       "secondaryPhoneNumber",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Phone,
 	Attributes: form.FormElementAttributes{Name: "secondaryPhoneNumber"},
 	Translations: []AttributeTranslation{
@@ -720,6 +745,7 @@ var SecondaryPhoneNumberAttribute = Attribute{
 var TertiaryPhoneNumberAttribute = Attribute{
 	ID:         "4a0ba072-66a5-403f-bea1-35e9427659fb",
 	Name:       "tertiaryPhoneNumber",
+	CountryID: 	GlobalCountry.ID,
 	Type:       form.Phone,
 	Attributes: form.FormElementAttributes{Name: "tertiaryPhoneNumber"},
 	Translations: []AttributeTranslation{
@@ -738,6 +764,7 @@ var TertiaryPhoneNumberAttribute = Attribute{
 var PreferredMeansOfContactAttribute = Attribute{
 	ID:   "1e7f2db9-eb63-46ae-b6d5-5c171a9e2534",
 	Name: "preferredMeansOfContact",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Dropdown,
 	Attributes: form.FormElementAttributes{
 		Name:    "preferredMeansOfContact",
@@ -759,6 +786,7 @@ var PreferredMeansOfContactAttribute = Attribute{
 var RequireAnInterpreterAttribute = Attribute{
 	ID:   "9b6ae87d-8935-49aa-9e32-26e7445d1afc",
 	Name: "requireAnInterpreter",
+	CountryID: 	GlobalCountry.ID,
 	Type: form.Checkbox,
 	Attributes: form.FormElementAttributes{
 		Name:            "requireAnInterpreter",
@@ -819,6 +847,7 @@ var CountryPartyType = PartyType{
 var TeamNameAttribute = Attribute{
 	ID:                           "18f410a3-6fde-45ce-80c7-fc5d92b85870",
 	Name:                         "teamName",
+	CountryID: 	GlobalCountry.ID,
 	PartyTypeIDs:                 []string{TeamPartyType.ID},
 	IsPersonallyIdentifiableInfo: false,
 	Translations: []AttributeTranslation{
@@ -833,6 +862,7 @@ var TeamNameAttribute = Attribute{
 var CountryNameAttribute = Attribute{
 	ID:                           "e011d638-864b-496e-b3e5-af89d0278e1e",
 	Name:                         "countryName",
+	CountryID: 	GlobalCountry.ID,
 	PartyTypeIDs:                 []string{CountryPartyType.ID},
 	IsPersonallyIdentifiableInfo: false,
 	Translations: []AttributeTranslation{

--- a/api/pkg/apps/webapp/attributes.go
+++ b/api/pkg/apps/webapp/attributes.go
@@ -29,46 +29,12 @@ func (s *Server) Attributes(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	session, err := s.sessionManager.Get(req)
-	if err != nil {
-		s.Error(w, err)
-	}
-
-	profileIntf, ok := session.Values["profile"]
-	if !ok {
-		logrus.Errorf("profile not found")
-	}
-
-	claims, ok := profileIntf.(*Claims)
-	if !ok {
-		logrus.Errorf("claims not found")
-	}
-
-	membership, err := iamClient.Memberships().List(ctx, iam.MembershipListOptions{
-		IndividualID: claims.Subject,
-	})
-
-	var teamID string
-	if len((*membership).Items) == 1 {
-		teamID = (*membership).Items[0].TeamID
-	} else {
-		logrus.Errorf("User %s has no team or more than one team", claims.Subject)
-	}
-
-	nationality, err:= iamClient.Nationalities().List(ctx, iam.NationalityListOptions{TeamID: teamID})
-
-	var countryID string
-	if len((*nationality).Items) == 1 {
-		countryID = (*nationality).Items[0].CountryID
-	} else {
-		logrus.Errorf("Team %s has no nationality or more than one nationality", teamID)
-	}
-
-	logrus.Infof("User id: %s", claims.Subject)
-	logrus.Infof("Team id: %s", teamID)
+	countryID := s.GetCountryFromLoginUser(w, req)
 	logrus.Infof("Country id: %s", countryID)
 
-	list, err := iamClient.Attributes().List(ctx, iam.AttributeListOptions{})
+	list, err := iamClient.Attributes().List(ctx, iam.AttributeListOptions{
+		CountryIDs: []string{countryID},
+	})
 	if err != nil {
 		s.Error(w, err)
 		return

--- a/api/pkg/apps/webapp/attributes.go
+++ b/api/pkg/apps/webapp/attributes.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nrc-no/core/pkg/apps/iam"
 	"github.com/nrc-no/core/pkg/sessionmanager"
 	uuid "github.com/satori/go.uuid"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,7 +29,6 @@ func (s *Server) Attributes(w http.ResponseWriter, req *http.Request) {
 	}
 
 	countryID := s.GetCountryFromLoginUser(w, req)
-	logrus.Infof("Country id: %s", countryID)
 
 	list, err := iamClient.Attributes().List(ctx, iam.AttributeListOptions{
 		CountryIDs: []string{iam.GlobalCountry.ID, countryID},

--- a/api/pkg/apps/webapp/attributes.go
+++ b/api/pkg/apps/webapp/attributes.go
@@ -33,7 +33,7 @@ func (s *Server) Attributes(w http.ResponseWriter, req *http.Request) {
 	logrus.Infof("Country id: %s", countryID)
 
 	list, err := iamClient.Attributes().List(ctx, iam.AttributeListOptions{
-		CountryIDs: []string{countryID},
+		CountryIDs: []string{iam.GlobalCountry.ID, countryID},
 	})
 	if err != nil {
 		s.Error(w, err)

--- a/api/pkg/apps/webapp/individuals.go
+++ b/api/pkg/apps/webapp/individuals.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nrc-no/core/pkg/teamstatusctrl"
 	"github.com/nrc-no/core/pkg/utils"
 	"github.com/nrc-no/core/pkg/validation"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"strconv"
@@ -225,10 +226,14 @@ func (s *Server) Individual(w http.ResponseWriter, req *http.Request) {
 		return err
 	})
 
+	countryID := s.GetCountryFromLoginUser(w, req)
+	logrus.Infof("Country id: %s", countryID)
+
 	g.Go(func() error {
 		var err error
 		attrs, err = iamClient.Attributes().List(waitCtx, iam.AttributeListOptions{
 			PartyTypeIDs: []string{iam.IndividualPartyType.ID},
+			CountryIDs: []string{countryID},
 		})
 		return err
 	})

--- a/api/pkg/apps/webapp/individuals.go
+++ b/api/pkg/apps/webapp/individuals.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nrc-no/core/pkg/teamstatusctrl"
 	"github.com/nrc-no/core/pkg/utils"
 	"github.com/nrc-no/core/pkg/validation"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"strconv"
@@ -227,7 +226,6 @@ func (s *Server) Individual(w http.ResponseWriter, req *http.Request) {
 	})
 
 	countryID := s.GetCountryFromLoginUser(w, req)
-	logrus.Infof("Country id: %s", countryID)
 
 	g.Go(func() error {
 		var err error

--- a/api/pkg/apps/webapp/individuals.go
+++ b/api/pkg/apps/webapp/individuals.go
@@ -233,7 +233,7 @@ func (s *Server) Individual(w http.ResponseWriter, req *http.Request) {
 		var err error
 		attrs, err = iamClient.Attributes().List(waitCtx, iam.AttributeListOptions{
 			PartyTypeIDs: []string{iam.IndividualPartyType.ID},
-			CountryIDs: []string{countryID},
+			CountryIDs: []string{iam.GlobalCountry.ID, countryID},
 		})
 		return err
 	})

--- a/api/pkg/apps/webapp/profile.go
+++ b/api/pkg/apps/webapp/profile.go
@@ -1,0 +1,70 @@
+package webapp
+
+import (
+	"github.com/nrc-no/core/pkg/apps/iam"
+	"github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func (s *Server) GetProfile(w http.ResponseWriter, req *http.Request)(*Claims) {
+	session, err := s.sessionManager.Get(req)
+	if err != nil {
+		s.Error(w, err)
+	}
+
+	profileIntf, ok := session.Values["profile"]
+	if !ok {
+		logrus.Errorf("profile not found")
+	}
+
+	claims, ok := profileIntf.(*Claims)
+	if !ok {
+		logrus.Errorf("claims not found")
+	}
+	return claims
+}
+
+func (s *Server) GetTeamFromLoginUser(w http.ResponseWriter, req *http.Request) string {
+	ctx := req.Context()
+
+	iamClient, err := s.IAMClient(req)
+	if err != nil {
+		s.Error(w, err)
+		return ""
+	}
+
+	claims := s.GetProfile(w, req)
+
+	membership, err := iamClient.Memberships().List(ctx, iam.MembershipListOptions{
+		IndividualID: claims.Subject,
+	})
+
+	var teamID string
+	if len((*membership).Items) == 1 {
+		teamID = (*membership).Items[0].TeamID
+	} else {
+		logrus.Errorf("User %s has no team or more than one team", claims.Subject)
+	}
+	return teamID
+}
+
+func (s *Server) GetCountryFromLoginUser(w http.ResponseWriter, req *http.Request) string {
+	ctx := req.Context()
+
+	iamClient, err := s.IAMClient(req)
+	if err != nil {
+		s.Error(w, err)
+		return ""
+	}
+	teamID := s.GetTeamFromLoginUser(w, req)
+	nationality, err:= iamClient.Nationalities().List(ctx, iam.NationalityListOptions{TeamID: teamID})
+
+	var countryID string
+	if len((*nationality).Items) == 1 {
+		countryID = (*nationality).Items[0].CountryID
+	} else {
+		logrus.Errorf("Team %s has no nationality or more than one nationality", teamID)
+	}
+	return countryID
+
+}


### PR DESCRIPTION
- Added `CountryID` to `Attribute`. Each attribute is now given either `GlobalCountry.ID` or a specific country ID defined in `iam.static.go`
- Added `CountryIDs` to `AttributeListOptions`. By passing `CountryIDs: []string{iam.GlobalCountry.ID, countryID}` we get attributes that are either global or match countryID
- Added `GetCountryFromLoginUser` in `profile.go`, which returns the country ID of the team of the login user.
- Attributes in `Attribute Settings` and `Individuals` are now only showing global attributes and attributes specific to login user's country.