### PR TITLE
COR-243: Refactor e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.out
 api/tmp/
 vendor/
+actions/__tmp

--- a/e2e/cypress/integration/attribute.spec.js
+++ b/e2e/cypress/integration/attribute.spec.js
@@ -2,7 +2,7 @@ import AttributePage from '../pages/attributePage';
 import AttributeOverviewPage from '../pages/attributeOverview.page';
 import ids from '../fixtures/ids.json';
 import { URL } from '../helpers';
-import './commands';
+import '../support/commands';
 
 const DATA = {
     NAME: 'Test attribute',

--- a/e2e/cypress/integration/attribute.spec.js
+++ b/e2e/cypress/integration/attribute.spec.js
@@ -20,6 +20,9 @@ const DATA = {
 
 // FIXME COR-204
 describe.skip('Attribute Page', function () {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Navigate', () => {
         it('should navigate to the New Attribute page from the attributes page', () => {
             const attributeOverviewPage = new AttributeOverviewPage();

--- a/e2e/cypress/integration/attribute.spec.js
+++ b/e2e/cypress/integration/attribute.spec.js
@@ -2,6 +2,7 @@ import AttributePage from '../pages/attributePage';
 import AttributeOverviewPage from '../pages/attributeOverview.page';
 import ids from '../fixtures/ids.json';
 import { URL } from '../helpers';
+import './commands';
 
 const DATA = {
     NAME: 'Test attribute',

--- a/e2e/cypress/integration/attribute.spec.js
+++ b/e2e/cypress/integration/attribute.spec.js
@@ -21,7 +21,7 @@ const DATA = {
 
 // FIXME COR-204
 describe.skip('Attribute Page', function () {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Navigate', () => {

--- a/e2e/cypress/integration/case.spec.js
+++ b/e2e/cypress/integration/case.spec.js
@@ -6,7 +6,7 @@ import CasePage from '../pages/case.page';
 import CaseTypePage from '../pages/caseTypePage';
 import testTemplate from '../fixtures/test_casetemplate.json';
 import CasetypesOverviewPage from '../pages/casetypesOverview.page';
-import './commands';
+import '../support/commands';
 
 const DATA = {
     NAME: 'test casetype',

--- a/e2e/cypress/integration/case.spec.js
+++ b/e2e/cypress/integration/case.spec.js
@@ -6,6 +6,7 @@ import CasePage from '../pages/case.page';
 import CaseTypePage from '../pages/caseTypePage';
 import testTemplate from '../fixtures/test_casetemplate.json';
 import CasetypesOverviewPage from '../pages/casetypesOverview.page';
+import './commands';
 
 const DATA = {
     NAME: 'test casetype',

--- a/e2e/cypress/integration/case.spec.js
+++ b/e2e/cypress/integration/case.spec.js
@@ -39,8 +39,10 @@ const DATA = {
 };
 
 describe('Case Page', function () {
-    before('Seed DB with test casetype', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
+    });
+    before('Seed DB with test casetype', () => {
         const caseTypePage = new CaseTypePage();
         caseTypePage
             .setName(DATA.NAME)

--- a/e2e/cypress/integration/case.spec.js
+++ b/e2e/cypress/integration/case.spec.js
@@ -43,6 +43,7 @@ describe('Case Page', function () {
         cy.login('courtney.lare@email.com');
     });
     before('Seed DB with test casetype', () => {
+        cy.login('courtney.lare@email.com');
         const caseTypePage = new CaseTypePage();
         caseTypePage
             .setName(DATA.NAME)

--- a/e2e/cypress/integration/casetype.spec.js
+++ b/e2e/cypress/integration/casetype.spec.js
@@ -13,6 +13,9 @@ const DATA = {
 };
 
 describe('CaseType Page', () => {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Navigate', () => {
         it('should navigate to new CaseType page from CaseTypes overview page', () => {
             const casetypesOverviewPage = new CasetypesOverviewPage();

--- a/e2e/cypress/integration/casetype.spec.js
+++ b/e2e/cypress/integration/casetype.spec.js
@@ -14,7 +14,7 @@ const DATA = {
 };
 
 describe('CaseType Page', () => {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Navigate', () => {

--- a/e2e/cypress/integration/casetype.spec.js
+++ b/e2e/cypress/integration/casetype.spec.js
@@ -3,6 +3,7 @@ import { URL } from '../helpers';
 import ids from '../fixtures/ids.json';
 import testTemplate from '../fixtures/test_casetemplate.json';
 import CasetypesOverviewPage from '../pages/casetypesOverview.page';
+import './commands';
 
 const DATA = {
     NAME: 'Test casetype',

--- a/e2e/cypress/integration/casetype.spec.js
+++ b/e2e/cypress/integration/casetype.spec.js
@@ -3,7 +3,7 @@ import { URL } from '../helpers';
 import ids from '../fixtures/ids.json';
 import testTemplate from '../fixtures/test_casetemplate.json';
 import CasetypesOverviewPage from '../pages/casetypesOverview.page';
-import './commands';
+import '../support/commands';
 
 const DATA = {
     NAME: 'Test casetype',

--- a/e2e/cypress/integration/individual.spec.js
+++ b/e2e/cypress/integration/individual.spec.js
@@ -1,6 +1,6 @@
 import IndividualPage from '../pages/individualPage';
 import IndividualOverviewPage from '../pages/individualOverview.page';
-import './commands';
+import '../support/commands';
 
 const data = {
     attributes: {

--- a/e2e/cypress/integration/individual.spec.js
+++ b/e2e/cypress/integration/individual.spec.js
@@ -38,7 +38,7 @@ function getTestIndividual(displayName) {
 }
 
 describe.skip('Individual Page', function () {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Navigate', () => {

--- a/e2e/cypress/integration/individual.spec.js
+++ b/e2e/cypress/integration/individual.spec.js
@@ -37,6 +37,9 @@ function getTestIndividual(displayName) {
 }
 
 describe.skip('Individual Page', function () {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Navigate', () => {
         it('should navigate to new Individual page from Individuals overview', () => {
             const individualOverviewPage = new IndividualOverviewPage();

--- a/e2e/cypress/integration/individual.spec.js
+++ b/e2e/cypress/integration/individual.spec.js
@@ -1,5 +1,6 @@
 import IndividualPage from '../pages/individualPage';
 import IndividualOverviewPage from '../pages/individualOverview.page';
+import './commands';
 
 const data = {
     attributes: {

--- a/e2e/cypress/integration/pagination.spec.js
+++ b/e2e/cypress/integration/pagination.spec.js
@@ -1,4 +1,5 @@
 import PaginationPage from '../pages/pagination.page';
+import './commands';
 
 describe('Pagination Page', function () {
     before('Login', () => {

--- a/e2e/cypress/integration/pagination.spec.js
+++ b/e2e/cypress/integration/pagination.spec.js
@@ -1,5 +1,5 @@
 import PaginationPage from '../pages/pagination.page';
-import './commands';
+import '../support/commands';
 
 describe('Pagination Page', function () {
     before('Login', () => {

--- a/e2e/cypress/integration/pagination.spec.js
+++ b/e2e/cypress/integration/pagination.spec.js
@@ -1,6 +1,9 @@
 import PaginationPage from '../pages/pagination.page';
 
 describe('Pagination Page', function () {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Should Navigate to Next and Previous Page', () => {
         it('should start on first page', () => {
             const paginationPage = new PaginationPage();

--- a/e2e/cypress/integration/pagination.spec.js
+++ b/e2e/cypress/integration/pagination.spec.js
@@ -2,7 +2,7 @@ import PaginationPage from '../pages/pagination.page';
 import '../support/commands';
 
 describe('Pagination Page', function () {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Should Navigate to Next and Previous Page', () => {

--- a/e2e/cypress/integration/partytype.spec.js
+++ b/e2e/cypress/integration/partytype.spec.js
@@ -1,5 +1,6 @@
 import NewPartyTypePage from '../pages/newPartyType.page';
 import PartytypesOverviewPage from '../pages/partytypeOverview.page';
+import './commands';
 
 const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';

--- a/e2e/cypress/integration/partytype.spec.js
+++ b/e2e/cypress/integration/partytype.spec.js
@@ -5,6 +5,9 @@ const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';
 
 describe('PartyType Page', function () {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Create', () => {
         it('should navigate to New PartyType Form Page and save new attribute', () => {
             const newPartyTypePage = new NewPartyTypePage();

--- a/e2e/cypress/integration/partytype.spec.js
+++ b/e2e/cypress/integration/partytype.spec.js
@@ -1,6 +1,6 @@
 import NewPartyTypePage from '../pages/newPartyType.page';
 import PartytypesOverviewPage from '../pages/partytypeOverview.page';
-import './commands';
+import '../support/commands';
 
 const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';

--- a/e2e/cypress/integration/partytype.spec.js
+++ b/e2e/cypress/integration/partytype.spec.js
@@ -6,7 +6,7 @@ const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';
 
 describe('PartyType Page', function () {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Create', () => {

--- a/e2e/cypress/integration/relationshiptype.spec.js
+++ b/e2e/cypress/integration/relationshiptype.spec.js
@@ -6,7 +6,7 @@ const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';
 
 describe('Relationshiptype Page', function () {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Create', () => {

--- a/e2e/cypress/integration/relationshiptype.spec.js
+++ b/e2e/cypress/integration/relationshiptype.spec.js
@@ -1,5 +1,6 @@
 import NewRelationshiptypePage from '../pages/newRelationshiptype.page';
 import RelationshiptypeOverviewPage from '../pages/relationshiptypeOverview.page';
+import './commands';
 
 const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';

--- a/e2e/cypress/integration/relationshiptype.spec.js
+++ b/e2e/cypress/integration/relationshiptype.spec.js
@@ -1,6 +1,6 @@
 import NewRelationshiptypePage from '../pages/newRelationshiptype.page';
 import RelationshiptypeOverviewPage from '../pages/relationshiptypeOverview.page';
-import './commands';
+import '../support/commands';
 
 const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';

--- a/e2e/cypress/integration/relationshiptype.spec.js
+++ b/e2e/cypress/integration/relationshiptype.spec.js
@@ -5,6 +5,9 @@ const TYPE_NAME = 'New Test';
 const EDITED_TYPE_NAME = 'Test Edited';
 
 describe('Relationshiptype Page', function () {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Create', () => {
         it('should navigate to New Relationshiptype Form Page and save new attribute', () => {
             const newRelationshiptypePage = new NewRelationshiptypePage();

--- a/e2e/cypress/integration/team.spec.js
+++ b/e2e/cypress/integration/team.spec.js
@@ -5,7 +5,7 @@ const SEARCH_NAME = 'FOCKE, Robert';
 const MEMBER_SHOWN_NAME = 'Robert Focke';
 
 describe('Teams Page', function () {
-    before('Login', () => {
+    beforeEach('Login', () => {
         cy.login('courtney.lare@email.com');
     });
     describe('Create', () => {

--- a/e2e/cypress/integration/team.spec.js
+++ b/e2e/cypress/integration/team.spec.js
@@ -4,6 +4,9 @@ const SEARCH_NAME = 'FOCKE, Robert';
 const MEMBER_SHOWN_NAME = 'Robert Focke';
 
 describe('Teams Page', function () {
+    before('Login', () => {
+        cy.login('courtney.lare@email.com');
+    });
     describe('Create', () => {
         it('should navigate to Team Page, select the first team and add a new member', () => {
             const teamsOverviewPage = new TeamsOverviewPage();

--- a/e2e/cypress/integration/team.spec.js
+++ b/e2e/cypress/integration/team.spec.js
@@ -1,4 +1,5 @@
 import TeamsOverviewPage from '../pages/teamOverview.page';
+import './commands';
 
 const SEARCH_NAME = 'FOCKE, Robert';
 const MEMBER_SHOWN_NAME = 'Robert Focke';

--- a/e2e/cypress/integration/team.spec.js
+++ b/e2e/cypress/integration/team.spec.js
@@ -1,5 +1,5 @@
 import TeamsOverviewPage from '../pages/teamOverview.page';
-import './commands';
+import '../support/commands';
 
 const SEARCH_NAME = 'FOCKE, Robert';
 const MEMBER_SHOWN_NAME = 'Robert Focke';

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -20,4 +20,4 @@ import './commands';
 // require('./commands')
 
 // call our custom login with access token before each test
-beforeEach(() => cy.login('courtney.lare@email.com'));
+// beforeEach(() => cy.login('courtney.lare@email.com'));

--- a/e2e/cypress/support/index.js
+++ b/e2e/cypress/support/index.js
@@ -15,9 +15,3 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')
-
-// call our custom login with access token before each test
-// beforeEach(() => cy.login('courtney.lare@email.com'));


### PR DESCRIPTION
This aims to refactor end-to-end tests to allow for different login behaviour on a per test basis, replacing the global `beforeEach` login approach.

The rationale behind this is that certain tests will depend on a specific type of user being logged in, and we therefore need more granular control than a global catch all can provide.