### PR TITLE
COR-355: add validation to databases endpoint

### DIFF
--- a/pkg/server/public/handlers/database/create.go
+++ b/pkg/server/public/handlers/database/create.go
@@ -1,6 +1,9 @@
 package database
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/emicklei/go-restful/v3"
 	"github.com/nrc-no/core/pkg/api/meta"
 	"github.com/nrc-no/core/pkg/api/types"
@@ -8,7 +11,6 @@ import (
 	"github.com/nrc-no/core/pkg/logging"
 	"github.com/nrc-no/core/pkg/utils"
 	"go.uber.org/zap"
-	"net/http"
 )
 
 func (h *Handler) Create() http.HandlerFunc {
@@ -21,6 +23,12 @@ func (h *Handler) Create() http.HandlerFunc {
 		if err := utils.BindJSON(req, &db); err != nil {
 			l.Error("failed to unmarshal database", zap.Error(err))
 			utils.ErrorResponse(w, err)
+			return
+		}
+
+		if !ValidateDBStruct(&db) {
+			l.Error("invalid data")
+			utils.ErrorResponse(w, fmt.Errorf("invalid data"))
 			return
 		}
 

--- a/pkg/server/public/handlers/database/validation.go
+++ b/pkg/server/public/handlers/database/validation.go
@@ -1,0 +1,24 @@
+package database
+
+import (
+	"strings"
+
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/validation"
+)
+
+func ValidDBNameLength(name string) bool {
+	return len(name) >= 3 && len(name) <= 32
+}
+
+func DbNameHasNoLeadingOrTrailingWhitespace(name string) bool {
+	trimmed := strings.TrimSpace(name)
+	return name == trimmed
+}
+
+func ValidateDBStruct(db *types.Database) bool {
+	returnVal := validation.IsValidAlpha(db.Name)
+	returnVal = returnVal && ValidDBNameLength(db.Name)
+	returnVal = returnVal && DbNameHasNoLeadingOrTrailingWhitespace(db.Name)
+	return returnVal
+}

--- a/test/database_validation_test.go
+++ b/test/database_validation_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"strings"
+
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/server/public/handlers/database"
+	"github.com/stretchr/testify/assert"
+)
+
+func (s *Suite) TestDatabaseValidation() {
+	// test valid name length
+	tooShort := "aa"
+	tooLong := strings.Repeat("a", 33)
+	justRight := "aaaa"
+
+	assert.False(s.T(), database.ValidDBNameLength(tooShort))
+	assert.False(s.T(), database.ValidDBNameLength(tooLong))
+	assert.True(s.T(), database.ValidDBNameLength(justRight))
+
+	// test no leading or trailing whitespace
+	withSpacesAtFront := " \n\ttest"
+	withSpacesAtEnd := "test\n\t "
+	withSpacesAtBoth := " \n\ttest\n\t "
+	withoutSpaces := "test"
+
+	assert.False(s.T(), database.DbNameHasNoLeadingOrTrailingWhitespace(withSpacesAtFront))
+	assert.False(s.T(), database.DbNameHasNoLeadingOrTrailingWhitespace(withSpacesAtEnd))
+	assert.False(s.T(), database.DbNameHasNoLeadingOrTrailingWhitespace(withSpacesAtBoth))
+	assert.True(s.T(), database.DbNameHasNoLeadingOrTrailingWhitespace(withoutSpaces))
+
+	// test integrated valdation
+	dbStructWithEmojis := types.Database{
+		Name: "🕵️🕵️🕵️🕵️",
+	}
+
+	assert.False(s.T(), database.ValidateDBStruct(&dbStructWithEmojis))
+}


### PR DESCRIPTION
- Introduces a `validation.go` file to the database handler folder, which contains logic to valid `Database` structs
- Introduces unit tests for the validation logic
- Create handler now runs validation after unmarshalling data, returns error if it does not pass