### PR TITLE
Tests and documentation for the Folder store

### DIFF
--- a/.prow/push-core-go-test.yaml
+++ b/.prow/push-core-go-test.yaml
@@ -7,7 +7,7 @@ presubmits:
         - image: golang:1.16
           command: [ "bash", "-c" ]
           args:
-            - >
+            - |
               go mod download &&
               make gen &&
               git diff --exit-code &&

--- a/.prow/push-core-go-test.yaml
+++ b/.prow/push-core-go-test.yaml
@@ -7,7 +7,7 @@ presubmits:
         - image: golang:1.16
           command: [ "bash", "-c" ]
           args:
-            - |
+            - >
               go mod download &&
               make gen &&
               git diff --exit-code &&

--- a/pkg/api/meta/utils.go
+++ b/pkg/api/meta/utils.go
@@ -116,3 +116,18 @@ func reasonAndCodeForError(err error) (StatusReason, int32) {
 	}
 	return StatusReasonUnknown, 0
 }
+
+func HasCauseForError(err error, field string, cause CauseType) bool {
+	if status := APIStatus(nil); errors.As(err, &status) {
+		details := status.Status().Details
+		if details == nil {
+			return false
+		}
+		for _, statusCause := range details.Causes {
+			if statusCause.Type == cause && statusCause.Field == field {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/api/types/folder.go
+++ b/pkg/api/types/folder.go
@@ -1,5 +1,6 @@
 package types
 
+
 // Folder is a namespace for Forms.
 // Folder can be used to group FormDefinitions together.
 type Folder struct {

--- a/pkg/api/types/scheme.go
+++ b/pkg/api/types/scheme.go
@@ -5,8 +5,14 @@ import "github.com/nrc-no/core/pkg/api/meta"
 const group = "core.nrc.no"
 const version = "v1"
 const folders = "folders"
+const databases = "databases"
 
 var FolderGR = meta.GroupResource{
 	Group:    group,
 	Resource: folders,
+}
+
+var DatabaseGB = meta.GroupResource{
+	Group:    group,
+	Resource: databases,
 }

--- a/pkg/api/types/scheme.go
+++ b/pkg/api/types/scheme.go
@@ -1,0 +1,12 @@
+package types
+
+import "github.com/nrc-no/core/pkg/api/meta"
+
+const group = "core.nrc.no"
+const version = "v1"
+const folders = "folders"
+
+var FolderGR = meta.GroupResource{
+	Group:    group,
+	Resource: folders,
+}

--- a/pkg/server/public/handlers/folder/create.go
+++ b/pkg/server/public/handlers/folder/create.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nrc-no/core/pkg/api/types"
 	"github.com/nrc-no/core/pkg/logging"
 	"github.com/nrc-no/core/pkg/utils"
+	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
 	"net/http"
 )
@@ -21,6 +22,8 @@ func (h *Handler) Create() http.HandlerFunc {
 			utils.ErrorResponse(w, err)
 			return
 		}
+
+		folder.ID = uuid.NewV4().String()
 
 		l.Debug("storing folder")
 		respForm, err := h.store.Create(ctx, &folder)

--- a/pkg/store/constants.go
+++ b/pkg/store/constants.go
@@ -1,0 +1,3 @@
+package store
+
+const idpStoreName = "identity_provider"

--- a/pkg/store/database_test.go
+++ b/pkg/store/database_test.go
@@ -11,39 +11,39 @@ import (
 )
 
 // TestDatabaseCreate tests that we can create a database successfully
-func (d *Suite) TestDatabaseCreate() {
+func (s *Suite) TestDatabaseCreate() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := d.mustCreateDatabase(ctx)
-	got, err := d.dbStore.Get(ctx, db.ID)
-	if !assert.NoError(d.T(), err) {
+	db := s.mustCreateDatabase(ctx)
+	got, err := s.dbStore.Get(ctx, db.ID)
+	if !assert.NoError(s.T(), err) {
 		return
 	}
 
-	assert.Equal(d.T(), db, got)
+	assert.Equal(s.T(), db, got)
 }
 
 // TestDatabaseCreateShouldFailIfCreateSchemaFails tests that when creating a database,
 // the transaction will be rolled out in case that we fail to create the actual
 // SQL Schema for that database.
-func (d *Suite) TestDatabaseCreateShouldFailIfCreateSchemaFails() {
+func (s *Suite) TestDatabaseCreateShouldFailIfCreateSchemaFails() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// mock failure to create the SQL Schema
-	d.dbStore.createDatabaseSchema = func(db *gorm.DB, database *types.Database) error {
+	s.dbStore.createDatabaseSchema = func(db *gorm.DB, database *types.Database) error {
 		return errors.New("mock error")
 	}
 
 	var in = &types.Database{ID: uuid.NewV4().String(), Name: "my-database"}
-	if _, err := d.dbStore.Create(ctx, in); !assert.Error(d.T(), err) {
+	if _, err := s.dbStore.Create(ctx, in); !assert.Error(s.T(), err) {
 		return
 	}
 
 	// ensure the database was not stored somehow (cancelling transaction error)
-	if db, err := d.dbStore.Get(ctx, in.ID); !assert.Error(d.T(), err) {
-		d.T().Logf("%v", db)
+	if db, err := s.dbStore.Get(ctx, in.ID); !assert.Error(s.T(), err) {
+		s.T().Logf("%v", db)
 		return
 	}
 
@@ -52,129 +52,129 @@ func (d *Suite) TestDatabaseCreateShouldFailIfCreateSchemaFails() {
 // TestDatabaseCreateShouldFailIfNonUniqueDatabaseID tests that it's not possible
 // to create two databases with the same ID, and that we get a
 // meta.StatusReasonAlreadyExists error
-func (d *Suite) TestDatabaseCreateShouldFailIfNonUniqueDatabaseID() {
+func (s *Suite) TestDatabaseCreateShouldFailIfNonUniqueDatabaseID() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := d.mustCreateDatabase(ctx)
+	db := s.mustCreateDatabase(ctx)
 
 	// try recreating the same database
-	_, err := d.dbStore.Create(ctx, db)
-	if !assert.Error(d.T(), err) {
+	_, err := s.dbStore.Create(ctx, db)
+	if !assert.Error(s.T(), err) {
 		return
 	}
 
-	assert.Equal(d.T(), meta.StatusReasonAlreadyExists, meta.ReasonForError(err))
+	assert.Equal(s.T(), meta.StatusReasonAlreadyExists, meta.ReasonForError(err))
 }
 
 // TestDatabaseGet tests that we can get a database after creating it
-func (d *Suite) TestDatabaseGet() {
+func (s *Suite) TestDatabaseGet() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := d.mustCreateDatabase(ctx)
+	db := s.mustCreateDatabase(ctx)
 
-	out, err := d.dbStore.Get(ctx, db.ID)
-	if !assert.NoError(d.T(), err) {
+	out, err := s.dbStore.Get(ctx, db.ID)
+	if !assert.NoError(s.T(), err) {
 		return
 	}
 
-	assert.Equal(d.T(), db, out)
+	assert.Equal(s.T(), db, out)
 }
 
 // TestDatabaseGetShouldFailIfDatabaseDoesNotExist tests that we cannot get
 // a database if it does not exist, and that we get a
 // meta.StatusReasonNotFound
-func (d *Suite) TestDatabaseGetShouldFailIfDatabaseDoesNotExist() {
+func (s *Suite) TestDatabaseGetShouldFailIfDatabaseDoesNotExist() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, err := d.dbStore.Get(ctx, uuid.NewV4().String())
-	if !assert.Error(d.T(), err) {
+	_, err := s.dbStore.Get(ctx, uuid.NewV4().String())
+	if !assert.Error(s.T(), err) {
 		return
 	}
 
-	assert.Equal(d.T(), meta.StatusReasonNotFound, meta.ReasonForError(err))
+	assert.Equal(s.T(), meta.StatusReasonNotFound, meta.ReasonForError(err))
 }
 
 // TestDatabaseListShouldReturnEmptyArrayIfNoDatabases tests that listing databases
 // returns an empty list if there are no databases
-func (d *Suite) TestDatabaseListShouldReturnEmptyArrayIfNoDatabases() {
+func (s *Suite) TestDatabaseListShouldReturnEmptyArrayIfNoDatabases() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// clearing the databases beforehand
-	if err := d.db.Where("id = id").Delete(&Database{}).Error; !assert.NoError(d.T(), err) {
+	if err := s.db.Where("id = id").Delete(&Database{}).Error; !assert.NoError(s.T(), err) {
 		return
 	}
 
-	dbList, err := d.dbStore.List(ctx)
-	if !assert.NoError(d.T(), err) {
+	dbList, err := s.dbStore.List(ctx)
+	if !assert.NoError(s.T(), err) {
 		return
 	}
 
-	assert.Equal(d.T(), &types.DatabaseList{Items: []*types.Database{}}, dbList)
+	assert.Equal(s.T(), &types.DatabaseList{Items: []*types.Database{}}, dbList)
 }
 
 // TestDatabaseListShouldReturnDatabases tests that we can list the databases
-func (d *Suite) TestDatabaseListShouldReturnDatabases() {
+func (s *Suite) TestDatabaseListShouldReturnDatabases() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db1 := d.mustCreateDatabase(ctx)
-	db2 := d.mustCreateDatabase(ctx)
+	db1 := s.mustCreateDatabase(ctx)
+	db2 := s.mustCreateDatabase(ctx)
 
-	dbList, err := d.dbStore.List(ctx)
-	if !assert.NoError(d.T(), err) {
+	dbList, err := s.dbStore.List(ctx)
+	if !assert.NoError(s.T(), err) {
 		return
 	}
 
-	assert.Contains(d.T(), dbList.Items, db1)
-	assert.Contains(d.T(), dbList.Items, db2)
+	assert.Contains(s.T(), dbList.Items, db1)
+	assert.Contains(s.T(), dbList.Items, db2)
 }
 
 // TestDatabaseDelete tests that it's possible to delete a database, and that
 // trying to GET the database should result in
 // meta.StatusReasonNotFound
-func (d *Suite) TestDatabaseDelete() {
+func (s *Suite) TestDatabaseDelete() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := d.mustCreateDatabase(ctx)
+	db := s.mustCreateDatabase(ctx)
 
-	if err := d.dbStore.Delete(ctx, db.ID); !assert.NoError(d.T(), err) {
+	if err := s.dbStore.Delete(ctx, db.ID); !assert.NoError(s.T(), err) {
 		return
 	}
 
 	// test that we cannot get the database after deleting
-	_, err := d.dbStore.Get(ctx, db.ID)
-	if !assert.Error(d.T(), err) {
+	_, err := s.dbStore.Get(ctx, db.ID)
+	if !assert.Error(s.T(), err) {
 		return
 	}
 
-	assert.Equal(d.T(), meta.StatusReasonNotFound, meta.ReasonForError(err))
+	assert.Equal(s.T(), meta.StatusReasonNotFound, meta.ReasonForError(err))
 }
 
 // TestDatabaseDeleteFailsIfSchemaFailsToDelete tests that when deleting a database,
 // the transaction should roll back if deleting the SQL Schema fails to delete,
 // and that we can still get the database afterwards
-func (d *Suite) TestDatabaseDeleteFailsIfSchemaFailsToDelete() {
+func (s *Suite) TestDatabaseDeleteFailsIfSchemaFailsToDelete() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	db := d.mustCreateDatabase(ctx)
+	db := s.mustCreateDatabase(ctx)
 
 	// mock that deleting the SQL Schema fails
-	d.dbStore.deleteDatabaseSchema = func(db *gorm.DB, databaseId string) error {
+	s.dbStore.deleteDatabaseSchema = func(db *gorm.DB, databaseId string) error {
 		return errors.New("mock failure")
 	}
 
-	if err := d.dbStore.Delete(ctx, db.ID); !assert.Error(d.T(), err) {
+	if err := s.dbStore.Delete(ctx, db.ID); !assert.Error(s.T(), err) {
 		return
 	}
 
 	// test that we can still get the database after deleting (ensure no transaction error)
-	_, err := d.dbStore.Get(ctx, db.ID)
-	assert.NoError(d.T(), err)
+	_, err := s.dbStore.Get(ctx, db.ID)
+	assert.NoError(s.T(), err)
 
 }

--- a/pkg/store/database_test.go
+++ b/pkg/store/database_test.go
@@ -21,7 +21,7 @@ type DatabaseSuite struct {
 }
 
 func (d *DatabaseSuite) SetupSuite() {
-	db, err := gorm.Open(sqlite.Dialector{DSN: "file::memory:?cache=shared"}, &gorm.Config{
+	db, err := gorm.Open(sqlite.Dialector{DSN: "file::memory:?cache=shared&_foreign_keys=1"}, &gorm.Config{
 		SkipDefaultTransaction: true,
 	})
 	if err != nil {

--- a/pkg/store/errors.go
+++ b/pkg/store/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/jackc/pgconn"
 	"github.com/mattn/go-sqlite3"
+	"gorm.io/gorm"
 )
 
 const (
@@ -16,6 +17,10 @@ func IsUniqueConstraintErr(err error) bool {
 		return dbErr.IsUniqueConstraintErr()
 	}
 	return false
+}
+
+func IsNotFoundErr(err error) bool{
+	return errors.Is(err, gorm.ErrRecordNotFound)
 }
 
 func castDbErr(err error) (dbErr, bool) {

--- a/pkg/store/errors.go
+++ b/pkg/store/errors.go
@@ -12,6 +12,7 @@ const (
 	errPgUniqueViolation = "23505"
 )
 
+// IsUniqueConstraintErr returns whether the error is a Unique Constraint Violation error or not
 func IsUniqueConstraintErr(err error) bool {
 	if dbErr, ok := castDbErr(err); ok {
 		return dbErr.IsUniqueConstraintErr()
@@ -19,10 +20,12 @@ func IsUniqueConstraintErr(err error) bool {
 	return false
 }
 
-func IsNotFoundErr(err error) bool{
+// IsNotFoundErr returns whether the error is a Record Not Found error
+func IsNotFoundErr(err error) bool {
 	return errors.Is(err, gorm.ErrRecordNotFound)
 }
 
+// castDbErr casts the error as either a PostgreSQL or SQLite error
 func castDbErr(err error) (dbErr, bool) {
 	castSqliteErr := &sqlite3.Error{}
 	if errors.As(err, castSqliteErr) {
@@ -35,26 +38,32 @@ func castDbErr(err error) (dbErr, bool) {
 	return nil, false
 }
 
+// dbErr is the interface for database errors
 type dbErr interface {
 	IsUniqueConstraintErr() bool
 }
 
+// pgErr is the PostgreSQL implementation of dbErr
 type pgErr struct {
 	err *pgconn.PgError
 }
 
-func (s *pgErr) IsErrCode(code string) bool {
+// hasErrorCode returns whether the PostgreSQL error is of the given code
+func (s *pgErr) hasErrorCode(code string) bool {
 	return s.err.Code == code
 }
 
+// IsUniqueConstraintErr implements dbErr.IsUniqueConstraintErr
 func (s *pgErr) IsUniqueConstraintErr() bool {
-	return s.IsErrCode(errPgUniqueViolation)
+	return s.hasErrorCode(errPgUniqueViolation)
 }
 
+// sqliteErr is the SQLite implementation of dbErr
 type sqliteErr struct {
 	err *sqlite3.Error
 }
 
+// IsUniqueConstraintErr implements dbErr.IsUniqueConstraintErr
 func (s *sqliteErr) IsUniqueConstraintErr() bool {
 	if s.err.Code != sqlite3.ErrConstraint {
 		return false

--- a/pkg/store/factory.go
+++ b/pkg/store/factory.go
@@ -5,18 +5,25 @@ import (
 	"gorm.io/gorm"
 )
 
+// Factory is the store.Factory that returns an instance of a gorm.DB
+// This is useful because we can implement logic that allows us to
+// renew a database connection, for example, when a connection string changes
+// (credential rotation)
 type Factory interface {
 	Get() (*gorm.DB, error)
 }
 
+// factory is the implementation of Factory
 type factory struct {
 	db *gorm.DB
 }
 
+// Get implements Factory.Get
 func (f factory) Get() (*gorm.DB, error) {
 	return f.db, nil
 }
 
+// NewFactory returns a new instance of Factory
 func NewFactory(dsn string) (Factory, error) {
 	db, err := gorm.Open(postgres.New(postgres.Config{
 		DSN: dsn,
@@ -29,6 +36,7 @@ func NewFactory(dsn string) (Factory, error) {
 	}, nil
 }
 
+// NewMockFactory returns a mock Factory
 func NewMockFactory(db *gorm.DB) Factory {
 	return &factory{db: db}
 }

--- a/pkg/store/folder_test.go
+++ b/pkg/store/folder_test.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"context"
+	"github.com/nrc-no/core/pkg/api/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"testing"
+)
+
+type FolderSuite struct {
+	suite.Suite
+	db        *gorm.DB
+	dbFactory *factory
+	store     *folderStore
+}
+
+func (d *FolderSuite) SetupSuite() {
+	db, err := gorm.Open(sqlite.Dialector{DSN: "file::memory:?cache=shared&_foreign_keys=1"}, &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	db = db.Debug()
+	if err != nil {
+		d.FailNow(err.Error())
+	}
+	d.db = db
+	if err := db.AutoMigrate(&Database{}, &Folder{}); !assert.NoError(d.T(), err) {
+		d.FailNow(err.Error())
+	}
+	dbFactory := &factory{db: db}
+	d.dbFactory = dbFactory
+
+}
+
+func (d *FolderSuite) SetupTest() {
+	s := &folderStore{
+		db: d.dbFactory,
+	}
+	d.store = s
+}
+
+func (s *FolderSuite) TestCreateFolder() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	folder := &types.Folder{
+		ID:         uuid.NewV4().String(),
+		DatabaseID: "abc",
+		ParentID:   "",
+		Name:       "my-folder",
+	}
+	got, err := s.store.Create(ctx, folder)
+	if !assert.NoError(s.T(), err) {
+		return
+	}
+	actual, err := s.store.Get(ctx, folder.ID)
+	if !assert.NoError(s.T(), err) {
+		return
+	}
+	assert.Equal(s.T(), actual, got)
+}
+
+func TestFolderSuite(t *testing.T) {
+	suite.Run(t, new(FolderSuite))
+}

--- a/pkg/store/folder_test.go
+++ b/pkg/store/folder_test.go
@@ -2,67 +2,127 @@ package store
 
 import (
 	"context"
-	"github.com/nrc-no/core/pkg/api/types"
-	uuid "github.com/satori/go.uuid"
+	"github.com/nrc-no/core/pkg/api/meta"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"testing"
 )
 
-type FolderSuite struct {
-	suite.Suite
-	db        *gorm.DB
-	dbFactory *factory
-	store     *folderStore
+// TestFolderCreate tests that we can create a simple folder in a database
+func (s *Suite) TestFolderCreate() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db := s.mustCreateDatabase(ctx)
+	folder, err := s.createFolder(ctx, db.ID)
+	actual, err := s.folderStore.Get(ctx, folder.ID)
+	if !assert.NoError(s.T(), err) {
+		return
+	}
+	assert.Equal(s.T(), actual, folder)
 }
 
-func (d *FolderSuite) SetupSuite() {
-	db, err := gorm.Open(sqlite.Dialector{DSN: "file::memory:?cache=shared&_foreign_keys=1"}, &gorm.Config{
-		SkipDefaultTransaction: true,
-	})
-	db = db.Debug()
-	if err != nil {
-		d.FailNow(err.Error())
-	}
-	d.db = db
-	if err := db.AutoMigrate(&Database{}, &Folder{}); !assert.NoError(d.T(), err) {
-		d.FailNow(err.Error())
-	}
-	dbFactory := &factory{db: db}
-	d.dbFactory = dbFactory
-
-}
-
-func (d *FolderSuite) SetupTest() {
-	s := &folderStore{
-		db: d.dbFactory,
-	}
-	d.store = s
-}
-
-func (s *FolderSuite) TestCreateFolder() {
+// TestFolderCreateWithDuplicateID tests that it is not possible to create 2 folders with the same ID
+func (s *Suite) TestFolderCreateWithDuplicateID() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	folder := &types.Folder{
-		ID:         uuid.NewV4().String(),
-		DatabaseID: "abc",
-		ParentID:   "",
-		Name:       "my-folder",
-	}
-	got, err := s.store.Create(ctx, folder)
-	if !assert.NoError(s.T(), err) {
+	db := s.mustCreateDatabase(ctx)
+	folder := s.mustCreateFolder(ctx, db.ID)
+	_, err := s.folderStore.Create(ctx, folder)
+	if !assert.Error(s.T(), err) {
 		return
 	}
-	actual, err := s.store.Get(ctx, folder.ID)
-	if !assert.NoError(s.T(), err) {
-		return
-	}
-	assert.Equal(s.T(), actual, got)
+	assert.Equal(s.T(), meta.StatusReasonAlreadyExists, meta.ReasonForError(err))
 }
 
-func TestFolderSuite(t *testing.T) {
-	suite.Run(t, new(FolderSuite))
+// TestFolderCreateOnNotExistingDatabase tests that it is not possible to create a folder on a database that does not exist
+func (s *Suite) TestFolderCreateOnNotExistingDatabase() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := s.createFolder(ctx, "non-existing")
+	if !assert.Error(s.T(), err) {
+		return
+	}
+	assert.Equal(s.T(), meta.StatusReasonInvalid, meta.ReasonForError(err))
+	assert.True(s.T(), meta.HasCauseForError(err, "databaseId", meta.CauseTypeFieldValueNotFound))
+}
+
+// TestFolderCreateWithParent tests that it is possible to create a folder with a parent folder
+func (s *Suite) TestFolderCreateWithParent() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db := s.mustCreateDatabase(ctx)
+	parent := s.mustCreateFolder(ctx, db.ID)
+	folder := s.mustCreateFolderWithParent(ctx, db.ID, parent.ID)
+	assert.Equal(s.T(), parent.ID, folder.ParentID)
+}
+
+// TestFolderCreateWithNonExistingParent tests that it is not possible to create a folder with a parent that does not exist
+func (s *Suite) TestFolderCreateWithNonExistingParent() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db := s.mustCreateDatabase(ctx)
+	_, err := s.createFolderWithParent(ctx, db.ID, "non-existing")
+	if !assert.Error(s.T(), err) {
+		return
+	}
+	assert.Equal(s.T(), meta.StatusReasonInvalid, meta.ReasonForError(err))
+	assert.True(s.T(), meta.HasCauseForError(err, "parentId", meta.CauseTypeFieldValueNotFound))
+}
+
+// TestFolderDelete tests that it is possible to delete a folder
+func (s *Suite) TestFolderDelete() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db := s.mustCreateDatabase(ctx)
+	folder := s.mustCreateFolder(ctx, db.ID)
+	if err := s.folderStore.Delete(ctx, folder.ID); !assert.NoError(s.T(), err) {
+		return
+	}
+}
+
+// TestFolderParentDelete tests that it is possible to delete a parent folder
+func (s *Suite) TestFolderParentDelete() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db := s.mustCreateDatabase(ctx)
+	parent := s.mustCreateFolder(ctx, db.ID)
+	child := s.mustCreateFolderWithParent(ctx, db.ID, parent.ID)
+	if err := s.folderStore.Delete(ctx, parent.ID); !assert.NoError(s.T(), err) {
+		return
+	}
+	_, getChildErr := s.folderStore.Get(ctx, child.ID)
+	if !assert.Error(s.T(), getChildErr) {
+		return
+	}
+	assert.Equal(s.T(), meta.StatusReasonNotFound, meta.ReasonForError(getChildErr))
+	_, getParentErr := s.folderStore.Get(ctx, parent.ID)
+	if !assert.Error(s.T(), getParentErr) {
+		return
+	}
+	assert.Equal(s.T(), meta.StatusReasonNotFound, meta.ReasonForError(getParentErr))
+}
+
+// TestFolderDeleteNonExisting tests that it is not possible to delete a folder that does not exist
+func (s *Suite) TestFolderDeleteNonExisting() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := s.folderStore.Delete(ctx, "non-existing")
+	if !assert.Error(s.T(), err) {
+		return
+	}
+	assert.Equal(s.T(), meta.StatusReasonNotFound, meta.ReasonForError(err))
+}
+
+// TestListFolders tests that it is possible to list folders
+func (s *Suite) TestListFolders() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	db := s.mustCreateDatabase(ctx)
+	folder1 := s.mustCreateFolder(ctx, db.ID)
+	folder2 := s.mustCreateFolder(ctx, db.ID)
+	list, err := s.folderStore.List(ctx)
+	if !assert.NoError(s.T(), err) {
+		return
+	}
+	assert.Contains(s.T(), list.Items, folder1)
+	assert.Contains(s.T(), list.Items, folder2)
 }

--- a/pkg/store/identity_provider.go
+++ b/pkg/store/identity_provider.go
@@ -8,136 +8,186 @@ import (
 	"go.uber.org/zap"
 )
 
+// IdentityProvider is a class that represents an Organization IdentityProvider.
+// Organizations can register multiple IdentityProvider that they trust, through
+// which their staff will be allowed to log in.
+// For example, this could be an Okta, Auth0, GitHub identity provider.
+//
+// This struct is only used for storing types.IdentityProvider. This store
+// maps the types.IdentityProvider to and from the store.IdentityProvider.
+// This allows us to have flexibility into how we store the IdentityProvider
+// and how we present it to the API.
 type IdentityProvider struct {
-	ID             string
+
+	// ID is the Identity provider ID
+	ID string
+
+	// OrganizationID is the OrganizationID that owns this IdentityProvider
 	OrganizationID string
-	Organization   Organization
-	Domain         string
-	ClientID       string
-	ClientSecret   string
-	EmailDomain    string
-	Name           string
+
+	// Organization is the Organization that owns this IdentityProvider.
+	// We include this field here because gorm.DB creates the Foreign Key
+	// constraints when this field is present.
+	Organization Organization
+
+	// Domain represents the OIDC Issuer for this Identity Provider
+	Domain string
+
+	// ClientID represents the OAuth2 ClientID for this IdentityProvider
+	// For example, an Okta ClientID
+	ClientID string
+
+	// ClientSecret represents the OAuth2 ClientSecret for the IdentityProvider
+	// For example, an Okta ClientSecret
+	ClientSecret string
+
+	// EmailDomain represents the Domain of email addresses that should be
+	// using this identity provider.
+	// e.g. if EmailDomain = "my-org.com", then johndoe@my-org.com would use
+	// this IdentityProvider
+	EmailDomain string
+
+	// Name of this IdentityProvider
+	Name string
 }
 
+// IdentityProviders represent a list of IdentityProvider
+type IdentityProviders []*IdentityProvider
+
+// IdentityProviderListOptions represent the options when Listing IdentityProviders
 type IdentityProviderListOptions struct {
+	// ReturnClientSecret will include the IdentityProvider.ClientSecret in the response
 	ReturnClientSecret bool
 }
 
+// IdentityProviderGetOptions represent the options when getting an IdentityProvider
 type IdentityProviderGetOptions struct {
+	// ReturnClientSecret will include the IdentityProvider.ClientSecret in the response
 	ReturnClientSecret bool
 }
 
+// IdentityProviderCreateOptions represent the options when creating an IdentityProvider
 type IdentityProviderCreateOptions struct {
+	// ReturnClientSecret will include the IdentityProvider.ClientSecret in the response
 	ReturnClientSecret bool
 }
 
+// IdentityProviderUpdateOptions represent the options when updating an IdentityProvider
 type IdentityProviderUpdateOptions struct {
+	// ReturnClientSecret will include the IdentityProvider.ClientSecret in the response
 	ReturnClientSecret bool
 }
 
+// IdentityProviderStore is the store for IdentityProviders
 type IdentityProviderStore interface {
+	// List identity providers
 	List(ctx context.Context, organizationID string, options IdentityProviderListOptions) ([]*types.IdentityProvider, error)
+	// Get an IdentityProvider
 	Get(ctx context.Context, identityProviderId string, options IdentityProviderGetOptions) (*types.IdentityProvider, error)
+	// FindForEmailDomain finds IdentityProviders for the given email domain. Should only return one because we should not allow two
+	// identityProvider to use the same email domain
+	// TODO make this method return a single IdentityProvider
 	FindForEmailDomain(ctx context.Context, emailDomain string, options IdentityProviderListOptions) ([]*types.IdentityProvider, error)
-	Create(ctx context.Context, identityProvidr *types.IdentityProvider, options IdentityProviderCreateOptions) (*types.IdentityProvider, error)
-	Update(ctx context.Context, identityProvidr *types.IdentityProvider, options IdentityProviderUpdateOptions) (*types.IdentityProvider, error)
+	// Create an IdentityProvider
+	Create(ctx context.Context, identityProvider *types.IdentityProvider, options IdentityProviderCreateOptions) (*types.IdentityProvider, error)
+	// Update an IdentityProvider
+	Update(ctx context.Context, identityProvider *types.IdentityProvider, options IdentityProviderUpdateOptions) (*types.IdentityProvider, error)
 }
 
+// NewIdentityProviderStore returns a new IdentityProviderStore
 func NewIdentityProviderStore(db Factory) IdentityProviderStore {
 	return &identityProviderStore{db: db}
 }
 
+// identityProviderStore is the implementation of IdentityProviderStore
 type identityProviderStore struct {
 	db Factory
 }
 
+// Make sure identityProviderStore implements IdentityProviderStore
 var _ IdentityProviderStore = &identityProviderStore{}
 
+// List implements IdentityProviderStore.List
 func (i identityProviderStore) List(ctx context.Context, organizationID string, options IdentityProviderListOptions) ([]*types.IdentityProvider, error) {
-	ctx, db, l, done, err := actionContext(ctx, i.db, "identity_provider", "list", zap.String("organization_id", organizationID))
+	ctx, db, l, done, err := actionContext(ctx, i.db, idpStoreName, "list", zap.String("organization_id", organizationID))
 	if err != nil {
 		return nil, err
 	}
 	defer done()
 
-	l.Debug("listing identity providers")
-	var idps []*IdentityProvider
-	if err := db.WithContext(ctx).Find(&idps, "organization_id = ?", organizationID).Error; err != nil {
+	var storeIdps IdentityProviders
+	if err := db.WithContext(ctx).Find(&storeIdps, "organization_id = ?", organizationID).Error; err != nil {
 		l.Error("failed to list identity providers", zap.Error(err))
 		return nil, meta.NewInternalServerError(err)
 	}
-	if idps == nil {
-		idps = []*IdentityProvider{}
-	}
 
-	l.Debug("successfully listed identity providers")
-	return mapList(idps, options.ReturnClientSecret), nil
+	return mapIdentityProviderList(storeIdps, options.ReturnClientSecret), nil
 }
 
+// Get implements IdentityProviderStore.Get
 func (i identityProviderStore) Get(ctx context.Context, identityProviderId string, options IdentityProviderGetOptions) (*types.IdentityProvider, error) {
-	ctx, db, l, done, err := actionContext(ctx, i.db, "identity_provider", "get", zap.String("identity_provider_id", identityProviderId))
+	ctx, db, l, done, err := actionContext(ctx, i.db, idpStoreName, "get", zap.String("identity_provider_id", identityProviderId))
 	if err != nil {
 		return nil, err
 	}
 	defer done()
 
-	l.Debug("listing identity providers")
-	var idp *IdentityProvider
-	if err := db.WithContext(ctx).First(&idp, "id = ?", identityProviderId).Error; err != nil {
+	var storeIdp *IdentityProvider
+	if err := db.WithContext(ctx).First(&storeIdp, "id = ?", identityProviderId).Error; err != nil {
 		l.Error("failed to list identity providers", zap.Error(err))
 		return nil, meta.NewInternalServerError(err)
 	}
 
-	l.Debug("successfully listed identity providers")
-	return mapTo(idp, options.ReturnClientSecret), nil
+	return mapIdentityProviderTo(storeIdp, options.ReturnClientSecret), nil
 }
 
+// FindForEmailDomain implements IdentityProviderStore.FindForEmailDomain
 func (i identityProviderStore) FindForEmailDomain(ctx context.Context, emailDomain string, options IdentityProviderListOptions) ([]*types.IdentityProvider, error) {
-	ctx, db, l, done, err := actionContext(ctx, i.db, "identity_provider", "find_for_email_domain", zap.String("email_domain", emailDomain))
+	ctx, db, l, done, err := actionContext(ctx, i.db, idpStoreName, "find_for_email_domain", zap.String("email_domain", emailDomain))
 	if err != nil {
 		return nil, err
 	}
 	defer done()
 
-	l.Debug("finding identity providers for email domain")
-	var idps []*IdentityProvider
-	if err := db.WithContext(ctx).Find(&idps, "email_domain = ?", emailDomain).Error; err != nil {
-		l.Error("failed to find identity providers for email domain", zap.Error(err))
+	var storeIdps IdentityProviders
+	if err := db.WithContext(ctx).Find(&storeIdps, "email_domain = ?", emailDomain).Error; err != nil {
+		l.Error("failed to find identity providers for email domain", zap.Error(err), zap.String("email_domain", emailDomain))
 		return nil, meta.NewInternalServerError(err)
 	}
 
-	l.Debug("successfully found identity providers for email domain", zap.Int("count", len(idps)))
-	return mapList(idps, options.ReturnClientSecret), nil
+	return mapIdentityProviderList(storeIdps, options.ReturnClientSecret), nil
 }
 
-func (i identityProviderStore) Create(ctx context.Context, identityProvidr *types.IdentityProvider, options IdentityProviderCreateOptions) (*types.IdentityProvider, error) {
-	ctx, db, l, done, err := actionContext(ctx, i.db, "identity_provider", "create")
+// Create implements IdentityProviderStore.Create
+func (i identityProviderStore) Create(ctx context.Context, identityProvider *types.IdentityProvider, options IdentityProviderCreateOptions) (*types.IdentityProvider, error) {
+	ctx, db, l, done, err := actionContext(ctx, i.db, idpStoreName, "create")
 	if err != nil {
 		return nil, err
 	}
 	defer done()
 
-	idp := mapFrom(identityProvidr)
+	idp := mapIdentityProviderFrom(identityProvider)
 	idp.ID = uuid.NewV4().String()
 
-	l.Debug("creating identity provider")
 	if err := db.WithContext(ctx).Create(idp).Error; err != nil {
 		l.Error("failed to create identity provider", zap.Error(err))
 		return nil, meta.NewInternalServerError(err)
 	}
 
-	l.Debug("successfully created identity provider")
-	return mapTo(idp, options.ReturnClientSecret), nil
+	return mapIdentityProviderTo(idp, options.ReturnClientSecret), nil
 }
 
+// Update implements IdentityProviderStore.Update
 func (i identityProviderStore) Update(ctx context.Context, identityProvider *types.IdentityProvider, options IdentityProviderUpdateOptions) (*types.IdentityProvider, error) {
-	ctx, db, l, done, err := actionContext(ctx, i.db, "identity_provider", "update", zap.String("identity_provider_id", identityProvider.ID))
+	ctx, db, l, done, err := actionContext(ctx, i.db, idpStoreName, "update", zap.String("identity_provider_id", identityProvider.ID))
 	if err != nil {
 		return nil, err
 	}
 	defer done()
 
-	idp := mapFrom(identityProvider)
+	storeIdp := mapIdentityProviderFrom(identityProvider)
+
+	// these are the only fields allowed to be updated on an IdentityProvider
 	updates := map[string]interface{}{
 		"name":         identityProvider.Name,
 		"client_id":    identityProvider.ClientID,
@@ -148,12 +198,12 @@ func (i identityProviderStore) Update(ctx context.Context, identityProvider *typ
 		updates["client_secret"] = identityProvider.ClientSecret
 	}
 
-	l.Debug("updating identity provider")
-	result := db.WithContext(ctx).Model(&IdentityProvider{}).Where("id = ?", idp.ID).UpdateColumns(updates)
+	result := db.WithContext(ctx).Model(&IdentityProvider{}).Where("id = ?", storeIdp.ID).UpdateColumns(updates)
 	if err := result.Error; err != nil {
 		l.Error("failed to update identity provider", zap.Error(err))
 		return nil, meta.NewInternalServerError(err)
 	}
+
 	if result.RowsAffected == 0 {
 		l.Error("identity provider not found")
 		return nil, meta.NewNotFound(meta.GroupResource{
@@ -162,14 +212,14 @@ func (i identityProviderStore) Update(ctx context.Context, identityProvider *typ
 		}, identityProvider.ID)
 	}
 
-	l.Debug("successfully updated identity provider")
-	return mapTo(idp, options.ReturnClientSecret), nil
+	return mapIdentityProviderTo(storeIdp, options.ReturnClientSecret), nil
 }
 
-func mapList(i []*IdentityProvider, keepClientSecrets bool) []*types.IdentityProvider {
+// mapIdentityProviderList maps a list of store.IdentityProvider to a list of types.IdentityProvider
+func mapIdentityProviderList(i IdentityProviders, keepClientSecrets bool) []*types.IdentityProvider {
 	var result []*types.IdentityProvider
 	for _, provider := range i {
-		result = append(result, mapTo(provider, keepClientSecrets))
+		result = append(result, mapIdentityProviderTo(provider, keepClientSecrets))
 	}
 	if result == nil {
 		result = []*types.IdentityProvider{}
@@ -177,7 +227,8 @@ func mapList(i []*IdentityProvider, keepClientSecrets bool) []*types.IdentityPro
 	return result
 }
 
-func mapTo(i *IdentityProvider, keepClientSecret bool) *types.IdentityProvider {
+// mapIdentityProviderTo maps a store.IdentityProvider to a types.IdentityProvider
+func mapIdentityProviderTo(i *IdentityProvider, keepClientSecret bool) *types.IdentityProvider {
 	result := &types.IdentityProvider{
 		ID:             i.ID,
 		OrganizationID: i.OrganizationID,
@@ -192,7 +243,8 @@ func mapTo(i *IdentityProvider, keepClientSecret bool) *types.IdentityProvider {
 	return result
 }
 
-func mapFrom(i *types.IdentityProvider) *IdentityProvider {
+// mapIdentityProviderFrom maps a types.IdentityProvider into a store.IdentityProvider
+func mapIdentityProviderFrom(i *types.IdentityProvider) *IdentityProvider {
 	return &IdentityProvider{
 		ID:             i.ID,
 		OrganizationID: i.OrganizationID,

--- a/pkg/store/main_test.go
+++ b/pkg/store/main_test.go
@@ -1,0 +1,94 @@
+package store
+
+import (
+	"context"
+	"github.com/nrc-no/core/pkg/api/types"
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"testing"
+)
+
+type Suite struct {
+	suite.Suite
+	db          *gorm.DB
+	dbFactory   *factory
+	dbStore     *databaseStore
+	folderStore *folderStore
+}
+
+func (d *Suite) SetupSuite() {
+	db, err := gorm.Open(sqlite.Dialector{DSN: "file::memory:?cache=shared&_foreign_keys=1"}, &gorm.Config{
+		SkipDefaultTransaction: true,
+	})
+	db = db.Debug()
+	if err != nil {
+		d.FailNow(err.Error())
+	}
+	d.db = db
+	if err := db.AutoMigrate(&Database{}, &Form{}, &Field{}); !assert.NoError(d.T(), err) {
+		d.FailNow(err.Error())
+	}
+	dbFactory := &factory{
+		db: db,
+	}
+	d.dbFactory = dbFactory
+}
+
+func (d *Suite) SetupTest() {
+	d.dbStore = &databaseStore{
+		createDatabase: func(db *gorm.DB, database *types.Database) error {
+			return nil
+		},
+		deleteDatabase: func(db *gorm.DB, databaseId string) error {
+			return nil
+		},
+		db: d.dbFactory,
+	}
+	d.folderStore = &folderStore{
+		db: d.dbFactory,
+	}
+}
+
+func TestDatabaseSuite(t *testing.T) {
+	suite.Run(t, new(Suite))
+}
+
+func (s *Suite) mustCreateDatabase(ctx context.Context) *types.Database {
+	db := &types.Database{
+		ID:   uuid.NewV4().String(),
+		Name: "my-db",
+	}
+	if _, err := s.dbStore.Create(ctx, db); !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	return db
+}
+
+func (s *Suite) mustCreateFolder(ctx context.Context, databaseId string) *types.Folder {
+	return s.mustCreateFolderWithParent(ctx, databaseId, "")
+}
+
+func (s *Suite) createFolder(ctx context.Context, databaseId string) (*types.Folder, error) {
+	return s.createFolderWithParent(ctx, databaseId, "")
+}
+
+func (s *Suite) mustCreateFolderWithParent(ctx context.Context, databaseId, parentId string) *types.Folder {
+	folder, err := s.createFolderWithParent(ctx, databaseId, parentId)
+	if !assert.NoError(s.T(), err) {
+		s.T().FailNow()
+	}
+	return folder
+}
+
+func (s *Suite) createFolderWithParent(ctx context.Context, databaseId, parentId string) (*types.Folder, error) {
+	folder := &types.Folder{
+		ID:         uuid.NewV4().String(),
+		DatabaseID: databaseId,
+		Name:       "my-folder",
+		ParentID:   parentId,
+	}
+	return s.folderStore.Create(ctx, folder)
+}

--- a/pkg/store/main_test.go
+++ b/pkg/store/main_test.go
@@ -39,10 +39,10 @@ func (d *Suite) SetupSuite() {
 
 func (d *Suite) SetupTest() {
 	d.dbStore = &databaseStore{
-		createDatabase: func(db *gorm.DB, database *types.Database) error {
+		createDatabaseSchema: func(db *gorm.DB, database *types.Database) error {
 			return nil
 		},
-		deleteDatabase: func(db *gorm.DB, databaseId string) error {
+		deleteDatabaseSchema: func(db *gorm.DB, databaseId string) error {
 			return nil
 		},
 		db: d.dbFactory,
@@ -56,13 +56,19 @@ func TestDatabaseSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 
-func (s *Suite) mustCreateDatabase(ctx context.Context) *types.Database {
+func (s *Suite) createDatabase(ctx context.Context) (*types.Database, error) {
 	db := &types.Database{
 		ID:   uuid.NewV4().String(),
 		Name: "my-db",
 	}
-	if _, err := s.dbStore.Create(ctx, db); !assert.NoError(s.T(), err) {
-		s.T().FailNow()
+	return s.dbStore.Create(ctx, db)
+}
+
+func (s *Suite) mustCreateDatabase(ctx context.Context) *types.Database {
+	db, err := s.createDatabase(ctx)
+	if !assert.NoError(s.T(), err) {
+		s.T().Fail()
+		return nil
 	}
 	return db
 }

--- a/pkg/store/main_test.go
+++ b/pkg/store/main_test.go
@@ -52,7 +52,7 @@ func (d *Suite) SetupTest() {
 	}
 }
 
-func TestDatabaseSuite(t *testing.T) {
+func TestSuite(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 

--- a/pkg/store/main_test.go
+++ b/pkg/store/main_test.go
@@ -19,36 +19,36 @@ type Suite struct {
 	folderStore *folderStore
 }
 
-func (d *Suite) SetupSuite() {
+func (s *Suite) SetupSuite() {
 	db, err := gorm.Open(sqlite.Dialector{DSN: "file::memory:?cache=shared&_foreign_keys=1"}, &gorm.Config{
 		SkipDefaultTransaction: true,
 	})
 	db = db.Debug()
 	if err != nil {
-		d.FailNow(err.Error())
+		s.FailNow(err.Error())
 	}
-	d.db = db
-	if err := db.AutoMigrate(&Database{}, &Form{}, &Field{}); !assert.NoError(d.T(), err) {
-		d.FailNow(err.Error())
+	s.db = db
+	if err := db.AutoMigrate(&Database{}, &Form{}, &Field{}); !assert.NoError(s.T(), err) {
+		s.FailNow(err.Error())
 	}
 	dbFactory := &factory{
 		db: db,
 	}
-	d.dbFactory = dbFactory
+	s.dbFactory = dbFactory
 }
 
-func (d *Suite) SetupTest() {
-	d.dbStore = &databaseStore{
+func (s *Suite) SetupTest() {
+	s.dbStore = &databaseStore{
 		createDatabaseSchema: func(db *gorm.DB, database *types.Database) error {
 			return nil
 		},
 		deleteDatabaseSchema: func(db *gorm.DB, databaseId string) error {
 			return nil
 		},
-		db: d.dbFactory,
+		db: s.dbFactory,
 	}
-	d.folderStore = &folderStore{
-		db: d.dbFactory,
+	s.folderStore = &folderStore{
+		db: s.dbFactory,
 	}
 }
 


### PR DESCRIPTION
**Changes to the `store.Suite`**
There was already logic to setup a `store.DatabaseSuite` test suite. I've renamed this to just `store.Suite`. This `store.Suite` is the parent `Suite` for all store tests. 
So there is now `store.Suite` (instead of `store.DatabaseSuite`), and methods like
- `func (s *Suite) TestDatabaseCreate() {}`
- `func (s *Suite) TestFolderCreate() {}` 
- ...

**Changes in this PR**
- Removed unecessary `db.WithContext(ctx)`as this logic is already in the `store.actionContext`, which is the boilerplate code for all store actions.
- Added checks when creating a `Folder` for the existence of the `Database` and `parent` folder (if any), as well as the appropriate error messages
- Fixed error where a foreign key constraint would fail, even if we specify an empty string for the `Folder.parent`. 
- Fixed error where deleting a **parent** folder would fail because the foreign key constraint `OnDelete` was not set to `Cascade`
- Added tests for `store.FolderStore` for `create`, `get`, `list`, `delete`
