### PR TITLE
Core 381 frontend monorepo skeleton

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+**/node_modules/
+**/build
+**/yarn-error.log
+**/lerna-debug.log

--- a/frontend/apps/admin/package.json
+++ b/frontend/apps/admin/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.1.0",
   "description": "> TODO: description",
-  "author": "Ben McAlindin <bmcalindin@gmail.com>",
   "homepage": "https://github.com/nrc-no/core#readme",
   "repository": {
     "type": "git",

--- a/frontend/apps/admin/package.json
+++ b/frontend/apps/admin/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "admin",
+  "private": true,
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "author": "Ben McAlindin <bmcalindin@gmail.com>",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/frontend/apps/native/package.json
+++ b/frontend/apps/native/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.1.0",
   "description": "> TODO: description",
-  "author": "Ben McAlindin <bmcalindin@gmail.com>",
   "homepage": "https://github.com/nrc-no/core#readme",
   "repository": {
     "type": "git",

--- a/frontend/apps/native/package.json
+++ b/frontend/apps/native/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "native",
+  "private": true,
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "author": "Ben McAlindin <bmcalindin@gmail.com>",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/frontend/apps/pwa/package.json
+++ b/frontend/apps/pwa/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.1.0",
   "description": "> TODO: description",
-  "author": "Ben McAlindin <bmcalindin@gmail.com>",
   "homepage": "https://github.com/nrc-no/core#readme",
   "repository": {
     "type": "git",

--- a/frontend/apps/pwa/package.json
+++ b/frontend/apps/pwa/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pwa",
+  "private": true,
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "author": "Ben McAlindin <bmcalindin@gmail.com>",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/frontend/lerna.json
+++ b/frontend/lerna.json
@@ -1,0 +1,9 @@
+{
+  "packages": [
+    "apps/*",
+    "packages/*"
+  ],
+  "version": "independent",
+  "npmClient": "yarn",
+  "useWorkspaces": true
+}

--- a/frontend/lerna.json
+++ b/frontend/lerna.json
@@ -1,7 +1,8 @@
 {
   "packages": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "storybook"
   ],
   "version": "independent",
   "npmClient": "yarn",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
   },
   "workspaces": [
     "apps/*",
-    "packages/*"
+    "packages/*",
+    "storybook"
   ],
   "devDependencies": {
     "lerna": "^4.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend-root",
+  "private": true,
+  "scripts": {
+    "start:admin": "lerna run --scope admin start",
+    "start:native": "lerna run --scope native start",
+    "start:pwa": "lerna run --scope pwa start",
+    "build": "lerna run build",
+    "build:admin": "lerna run --scope admin build",
+    "build:native": "lerna run --scope native build",
+    "build:pwa": "lerna run --scope pwa build",
+    "build:core-api-client": "lerna run --scope core-api-client build",
+    "build:core-auth": "lerna run --scope core-auth build",
+    "lint": "lerna run lint",
+    "test": "lerna run test"
+  },
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "devDependencies": {
+    "lerna": "^4.0.0"
+  }
+}

--- a/frontend/packages/core-api-client/package.json
+++ b/frontend/packages/core-api-client/package.json
@@ -2,7 +2,6 @@
   "name": "core-api-client",
   "version": "0.1.0",
   "description": "> TODO: description",
-  "author": "Ben McAlindin <bmcalindin@gmail.com>",
   "homepage": "https://github.com/nrc-no/core#readme",
   "repository": {
     "type": "git",

--- a/frontend/packages/core-api-client/package.json
+++ b/frontend/packages/core-api-client/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "core-api-client",
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "author": "Ben McAlindin <bmcalindin@gmail.com>",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/frontend/packages/core-auth/package.json
+++ b/frontend/packages/core-auth/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "core-auth",
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "author": "Ben McAlindin <bmcalindin@gmail.com>",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/frontend/packages/core-auth/package.json
+++ b/frontend/packages/core-auth/package.json
@@ -2,7 +2,6 @@
   "name": "core-auth",
   "version": "0.1.0",
   "description": "> TODO: description",
-  "author": "Ben McAlindin <bmcalindin@gmail.com>",
   "homepage": "https://github.com/nrc-no/core#readme",
   "repository": {
     "type": "git",

--- a/frontend/packages/design-system/package.json
+++ b/frontend/packages/design-system/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "design-system",
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}

--- a/frontend/storybook/package.json
+++ b/frontend/storybook/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "storybook",
+  "private": true,
+  "version": "0.1.0",
+  "description": "> TODO: description",
+  "homepage": "https://github.com/nrc-no/core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nrc-no/core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/nrc-no/core/issues"
+  },
+  "scripts": {
+    "test": "echo \"Error: run tests from root\" && exit 1"
+  }
+}
+


### PR DESCRIPTION
Adds a new directory as a lerna root package, containing apps and packages. I've renamed some for clarity.

`web/admin` -> `frontend/apps/admin`
`web/app/frontend` -> `frontend/apps/native`
`web/pwa` -> `frontend/apps/pwa`
`web/auth` -> `frontend/packages/core-auth`
`web/app/client` -> `frontend/packages/core-api-client`
`web/designSystem` -> `frontend/packages/design-system`
`web/storyBook` -> `frontend/storybook`