### PR TITLE
Change Record Values from map to slice

### DIFF
--- a/pkg/api/types/record.go
+++ b/pkg/api/types/record.go
@@ -42,10 +42,26 @@ type Record struct {
 	// OwnerID represents the owner of the Record. In cases where
 	// a Record is part of a SubForm, this field records the "Owner" form ID.
 	OwnerID *string `json:"ownerId"`
-	// Values is an arbitrary map of values that correspond to the FormDefinition.Fields.
-	// The key of the map is the FieldDefinition.ID ! (not the FormDefinition.Name, not
-	// the FormDefinition.Code)
-	Values map[string]interface{} `json:"values"`
+	// Values is a list of values that correspond to the FormDefinition.Fields.
+	Values FieldValues `json:"values"`
+}
+
+type Records []Record
+
+type FieldValue struct {
+	FieldID string  `json:"fieldId"`
+	Value   *string `json:"value"`
+}
+
+type FieldValues []FieldValue
+
+func (f FieldValues) Find(fieldID string) (FieldValue, bool) {
+	for _, value := range f {
+		if value.FieldID == fieldID {
+			return value, true
+		}
+	}
+	return FieldValue{}, false
 }
 
 // RecordList represents a list of Record

--- a/pkg/server/public/handlers/record/create.go
+++ b/pkg/server/public/handlers/record/create.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nrc-no/core/pkg/api/types/validation"
 	"github.com/nrc-no/core/pkg/logging"
 	"github.com/nrc-no/core/pkg/utils"
+	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
 	"net/http"
 )
@@ -23,6 +24,8 @@ func (h *Handler) Create() http.HandlerFunc {
 			utils.ErrorResponse(w, err)
 			return
 		}
+
+		input.ID = uuid.NewV4().String()
 
 		l.Debug("getting form for record", zap.String("form_id", input.FormID))
 		form, err := h.formStore.Get(req.Context(), input.FormID)

--- a/pkg/sqlmanager/build_helpers.go
+++ b/pkg/sqlmanager/build_helpers.go
@@ -41,7 +41,7 @@ func buildKeyFieldActions(formInterface types.FormInterface) sqlActions {
 // the ID column is also configured to be the primary key
 func buildTableIDColumn() schema.SQLColumn {
 	return schema.SQLColumn{
-		Name: "id",
+		Name: keyIdColumn,
 		DataType: schema.SQLDataType{
 			VarChar: &schema.SQLDataTypeVarChar{
 				Length: 36,
@@ -59,7 +59,7 @@ func buildTableIDColumn() schema.SQLColumn {
 // The value for this column has a default value of NOW()
 func buildTableCreatedAtColumn() schema.SQLColumn {
 	return schema.SQLColumn{
-		Name:    "created_at",
+		Name:    keyCreatedAtColumn,
 		Default: "NOW()",
 		DataType: schema.SQLDataType{
 			Timestamp: &schema.SQLDataTypeTimestamp{

--- a/pkg/sqlmanager/build_subform_field.go
+++ b/pkg/sqlmanager/build_subform_field.go
@@ -34,7 +34,7 @@ func subFormFieldActions(formInterface types.FormInterface, fieldDefinition *typ
 // buildSubFormOwnerColumn creates the "owner_id" column. This is only applicable for SubForms.
 func buildSubFormOwnerColumn(formInterface types.FormInterface) schema.SQLColumn {
 	return schema.SQLColumn{
-		Name: "owner_id",
+		Name: keyOwnerIdColumn,
 		DataType: schema.SQLDataType{
 			VarChar: &schema.SQLDataTypeVarChar{
 				Length: 36,
@@ -50,7 +50,7 @@ func buildSubFormOwnerColumn(formInterface types.FormInterface) schema.SQLColumn
 				Reference: &schema.ReferenceSQLColumnConstraint{
 					Schema:   formInterface.GetOwner().GetDatabaseID(),
 					Table:    formInterface.GetOwner().GetFormID(),
-					Column:   "id",
+					Column:   keyIdColumn,
 					OnDelete: schema.ActionCascade,
 					OnUpdate: schema.ActionCascade,
 				},

--- a/pkg/sqlmanager/constants.go
+++ b/pkg/sqlmanager/constants.go
@@ -1,0 +1,9 @@
+package sqlmanager
+
+const (
+	keyIdColumn        = "id"
+	keyOwnerIdColumn   = "owner_id"
+	keyCreatedAtColumn = "created_at"
+	monthFieldFormat   = "2006-01"
+	dateFieldFormat    = "2006-01-02"
+)

--- a/pkg/sqlmanager/formreader.go
+++ b/pkg/sqlmanager/formreader.go
@@ -1,0 +1,268 @@
+package sqlmanager
+
+import (
+	"errors"
+	"fmt"
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/utils/pointers"
+	"strconv"
+	"time"
+)
+
+const (
+	errInvalidSQLDataType = "invalid sql data type"
+	errUnknownFieldF      = "unknown field '%s'"
+)
+
+func NewFormReader(form types.FormInterface, rows sqlReader) FormReader {
+	return &formReader{
+		form:      form,
+		sqlReader: rows,
+	}
+}
+
+type FormReader interface {
+	GetRecords() (*types.RecordList, error)
+}
+
+type formReader struct {
+	form      types.FormInterface
+	sqlReader sqlReader
+}
+
+func (f formReader) GetRecords() (*types.RecordList, error) {
+	return readRecords(f.form, f.sqlReader)
+}
+
+type sqlReader interface {
+	Columns() ([]string, error)
+	Next() bool
+	Scan(...interface{}) error
+}
+
+// readRecords will iterate through a series of SQL Rows and return a list of populated records
+func readRecords(form types.FormInterface, rows sqlReader) (*types.RecordList, error) {
+
+	result := &types.RecordList{
+		Items: []*types.Record{},
+	}
+
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	for rows.Next() {
+		values := make([]interface{}, len(columns))
+		if err := rows.Scan(&values); err != nil {
+			return nil, err
+		}
+		record := &types.Record{
+			FormID:     form.GetFormID(),
+			DatabaseID: form.GetDatabaseID(),
+		}
+		if err := readInRecord(record, form, columns, values); err != nil {
+			return nil, err
+		}
+		result.Items = append(result.Items, record)
+	}
+
+	return result, nil
+}
+
+// readInRecord will populate a record for a form from the given SQL columns and values
+func readInRecord(record *types.Record, form types.FormInterface, columns []string, values []interface{}) error {
+
+	formFields := form.GetFields()
+	formFieldMap := map[string]*types.FieldDefinition{}
+	for _, field := range formFields {
+		formFieldMap[field.ID] = field
+	}
+
+	for i, column := range columns {
+		columnValue := values[i]
+
+		switch column {
+		case keyIdColumn:
+			recordId, err := mapStringValue(columnValue)
+			if err != nil {
+				return err
+			}
+			record.ID = recordId
+			continue
+		case keyOwnerIdColumn:
+			ownerId, err := mapStringPointerValue(columnValue)
+			if err != nil {
+				return err
+			}
+			record.OwnerID = ownerId
+			continue
+		case keyCreatedAtColumn:
+			_, err := mapTimeValue(columnValue)
+			if err != nil {
+				return err
+			}
+			// todo: record.CreatedAt
+			continue
+		default:
+			formField, ok := formFieldMap[column]
+			if !ok {
+				return fmt.Errorf(errUnknownFieldF, column)
+			}
+			if err := readInRecordField(record, formField, columnValue); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+
+}
+
+// readInRecordField will populate a record types.FieldValue for the given field and value
+func readInRecordField(
+	record *types.Record,
+	field *types.FieldDefinition,
+	value interface{},
+) error {
+
+	fieldKind, err := field.FieldType.GetFieldKind()
+	if err != nil {
+		return err
+	}
+
+	switch fieldKind {
+	case types.FieldKindMonth, types.FieldKindDate:
+		readInDateField(record, field, value, fieldKind)
+	case types.FieldKindQuantity:
+		readInQuantityField(record, field, value)
+	case types.FieldKindSingleSelect:
+		readInSingleSelectField(record, field, value)
+	case types.FieldKindReference:
+		readInReferenceField(record, field, value)
+	case types.FieldKindText, types.FieldKindMultilineText:
+		readInTextField(record, field, value)
+	}
+
+	return nil
+}
+
+// readInReferenceField will populate a record types.FieldValue for a types.FieldTypeDate or types.FieldTypeMonth field from
+// an  SQL value
+func readInDateField(record *types.Record, field *types.FieldDefinition, value interface{}, fieldKind types.FieldKind) {
+	var timeFormat string
+	switch fieldKind {
+	case types.FieldKindMonth:
+		timeFormat = monthFieldFormat
+	case types.FieldKindDate:
+		timeFormat = dateFieldFormat
+	}
+	var monthStr *string
+	switch t := value.(type) {
+	case time.Time:
+		monthStr = pointers.String(t.Format(timeFormat))
+	case *time.Time:
+		if t != nil {
+			monthStr = pointers.String(t.Format(timeFormat))
+		}
+	}
+	record.Values = append(record.Values, types.FieldValue{
+		FieldID: field.ID,
+		Value:   monthStr,
+	})
+}
+
+// readInReferenceField will populate a record types.FieldValue for a types.FieldTypeReference field from
+// an  SQL value
+func readInReferenceField(record *types.Record, field *types.FieldDefinition, value interface{}) {
+	record.Values = append(record.Values, types.FieldValue{
+		FieldID: field.ID,
+		Value:   getStringColumnStringPtr(value),
+	})
+}
+
+// readInSingleSelectField will populate a record types.FieldValue for a types.FieldTypeSingleSelect field from
+// an  SQL value
+func readInSingleSelectField(record *types.Record, field *types.FieldDefinition, value interface{}) {
+	record.Values = append(record.Values, types.FieldValue{
+		FieldID: field.ID,
+		Value:   getStringColumnStringPtr(value),
+	})
+}
+
+// readInReferenceField will populate a record types.FieldValue for a types.FieldTypeText or
+// types.FieldTypeMultilineText field from an  SQL value
+func readInTextField(record *types.Record, field *types.FieldDefinition, value interface{}) {
+	record.Values = append(record.Values, types.FieldValue{
+		FieldID: field.ID,
+		Value:   getStringColumnStringPtr(value),
+	})
+}
+
+// readInQuantityField will populate a record types.FieldValue for a types.FieldTypeQuantity from an  SQL value
+func readInQuantityField(record *types.Record, field *types.FieldDefinition, value interface{}) {
+	record.Values = append(record.Values, types.FieldValue{
+		FieldID: field.ID,
+		Value:   getIntColumnStringPtr(value),
+	})
+}
+
+// getStringColumnStringPtr will coerce a string or *string into a *string
+func getStringColumnStringPtr(value interface{}) *string {
+	var textStr *string
+	switch t := value.(type) {
+	case string:
+		textStr = pointers.String(t)
+	case *string:
+		textStr = t
+	}
+	return textStr
+}
+
+// getIntColumnStringPtr will convert an int or *int into a *string
+func getIntColumnStringPtr(value interface{}) *string {
+	var intStr *string
+	switch t := value.(type) {
+	case int:
+		intStr = pointers.String(strconv.Itoa(t))
+	case *int:
+		if t != nil {
+			intStr = pointers.String(strconv.Itoa(*t))
+		}
+	}
+	return intStr
+}
+
+// mapStringValue will return a string value from an interface
+// useful when we know for sure that a columns contains a non-nullable string field
+func mapStringValue(value interface{}) (string, error) {
+	recordId, ok := value.(string)
+	if !ok {
+		return "", errors.New(errInvalidSQLDataType)
+	}
+	return recordId, nil
+}
+
+// mapStringPointerValue will return a string pointer value from an interface
+func mapStringPointerValue(value interface{}) (*string, error) {
+	var val *string
+	switch v := value.(type) {
+	case *string:
+		val = v
+	case string:
+		val = &v
+	default:
+		return nil, errors.New(errInvalidSQLDataType)
+	}
+	return val, nil
+}
+
+// mapTimeValue is useful when we know for sure that a columns contains a non-nullable time field
+func mapTimeValue(value interface{}) (time.Time, error) {
+	timeValue, ok := value.(time.Time)
+	if !ok {
+		return time.Time{}, errors.New(errInvalidSQLDataType)
+	}
+	return timeValue, nil
+}

--- a/pkg/sqlmanager/formreader_test.go
+++ b/pkg/sqlmanager/formreader_test.go
@@ -1,0 +1,306 @@
+package sqlmanager
+
+import (
+	"fmt"
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/testutils"
+	"github.com/nrc-no/core/pkg/utils/pointers"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_readRecords(t *testing.T) {
+
+	const (
+		formId       = "formId"
+		databaseId   = "databaseId"
+		keyMyFieldID = "myField"
+		ownerId      = "ownerId"
+		recordId     = "recordId"
+	)
+
+	formWithField := func(kind types.FieldKind, ) types.FormInterface {
+		fldOpt := []testutils.FieldOption{
+			testutils.FieldID(keyMyFieldID),
+			testutils.FieldTypeKind(kind),
+		}
+		fldOpt = append(fldOpt)
+		formOpts := []testutils.FormOption{
+			testutils.FormID(formId),
+			testutils.FormDatabaseID(databaseId),
+			testutils.FormFields(
+				testutils.AField(fldOpt...),
+			),
+		}
+		formOpts = append(formOpts)
+		return testutils.AForm(formOpts...)
+	}
+
+	recordWithValue := func(value *string, options ...testutils.RecordOption) types.Record {
+		r := &types.Record{
+			ID:         recordId,
+			DatabaseID: databaseId,
+			FormID:     formId,
+			Values: []types.FieldValue{
+				{
+					FieldID: keyMyFieldID,
+					Value:   value,
+				},
+			},
+		}
+		r = testutils.RecordOptions(options...)(r)
+		return *r
+	}
+
+	columns := func(cols ...string) []string {
+		return cols
+	}
+
+	singleRow := func(values ...interface{}) [][]interface{} {
+		return [][]interface{}{
+			values,
+		}
+	}
+
+	singleRecord := func(record types.Record) *types.RecordList {
+		return &types.RecordList{
+			Items: []*types.Record{
+				&record,
+			},
+		}
+	}
+
+	tests := []struct {
+		name          string
+		form          types.FormInterface
+		columns       []string
+		values        [][]interface{}
+		want          *types.RecordList
+		wantErr       bool
+		scanThrows    bool
+		columnsThrows bool
+	}{
+		{
+			name:    "form with text field",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, "abc"),
+			want:    singleRecord(recordWithValue(pointers.String("abc"))),
+		}, {
+			name:    "form with optional text field",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.String("abc")),
+			want:    singleRecord(recordWithValue(pointers.String("abc"))),
+		}, {
+			name:    "form with multiline text field",
+			form:    formWithField(types.FieldKindMultilineText),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, "abc"),
+			want:    singleRecord(recordWithValue(pointers.String("abc"))),
+		}, {
+			name:    "form with optional multiline text field",
+			form:    formWithField(types.FieldKindMultilineText),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.String("abc")),
+			want:    singleRecord(recordWithValue(pointers.String("abc"))),
+		}, {
+			name:    "form with quantity field",
+			form:    formWithField(types.FieldKindQuantity),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, 123),
+			want:    singleRecord(recordWithValue(pointers.String("123"))),
+		}, {
+			name:    "form with nullable quantity field",
+			form:    formWithField(types.FieldKindQuantity),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.Int(123)),
+			want:    singleRecord(recordWithValue(pointers.String("123"))),
+		}, {
+			name:    "form with date field",
+			form:    formWithField(types.FieldKindDate),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, time.Date(2020, 6, 26, 10, 20, 30, 0, time.UTC)),
+			want:    singleRecord(recordWithValue(pointers.String("2020-06-26"))),
+		}, {
+			name:    "form with nullable date field",
+			form:    formWithField(types.FieldKindDate),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.Time(time.Date(2020, 6, 26, 10, 20, 30, 0, time.UTC))),
+			want:    singleRecord(recordWithValue(pointers.String("2020-06-26"))),
+		}, {
+			name:    "form with month field",
+			form:    formWithField(types.FieldKindMonth),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, time.Date(2020, 6, 26, 10, 20, 30, 0, time.UTC)),
+			want:    singleRecord(recordWithValue(pointers.String("2020-06"))),
+		}, {
+			name:    "form with nullable month field",
+			form:    formWithField(types.FieldKindMonth),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.Time(time.Date(2020, 6, 26, 10, 20, 30, 0, time.UTC))),
+			want:    singleRecord(recordWithValue(pointers.String("2020-06"))),
+		}, {
+			name:    "form with reference field",
+			form:    formWithField(types.FieldKindReference),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, "otherRefId"),
+			want:    singleRecord(recordWithValue(pointers.String("otherRefId"))),
+		}, {
+			name:    "form with nullable reference field",
+			form:    formWithField(types.FieldKindReference),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.String("otherRefId")),
+			want:    singleRecord(recordWithValue(pointers.String("otherRefId"))),
+		}, {
+			name:    "form with owner id",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyOwnerIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, ownerId, "abc"),
+			want:    singleRecord(recordWithValue(pointers.String("abc"), testutils.RecordOwnerID(pointers.String(ownerId)))),
+		}, {
+			name:    "form with nullable owner id",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyOwnerIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, pointers.String(ownerId), "abc"),
+			want:    singleRecord(recordWithValue(pointers.String("abc"), testutils.RecordOwnerID(pointers.String(ownerId)))),
+		}, {
+			name:    "record with bad id",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(123, "abc"),
+			wantErr: true,
+		}, {
+			name:    "record with bad owner id",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyOwnerIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, 123, "abc"),
+			wantErr: true,
+		}, {
+			name:    "record with bad created_at",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, keyCreatedAtColumn, keyMyFieldID),
+			values:  singleRow(recordId, 123, "abc"),
+			wantErr: true,
+		}, {
+			name:    "record with unknown field name",
+			form:    formWithField(types.FieldKindText),
+			columns: columns(keyIdColumn, "someField"),
+			values:  singleRow(recordId, "abc"),
+			wantErr: true,
+		}, {
+			name:    "record with unknown field type",
+			form:    formWithField(types.FieldKindUnknown),
+			columns: columns(keyIdColumn, keyMyFieldID),
+			values:  singleRow(recordId, "abc"),
+			wantErr: true,
+		}, {
+			name:          "columns throws",
+			form:          formWithField(types.FieldKindUnknown),
+			columns:       columns(),
+			values:        singleRow(),
+			columnsThrows: true,
+			wantErr:       true,
+		}, {
+			name:       "scan throws",
+			form:       formWithField(types.FieldKindUnknown),
+			columns:    columns(),
+			values:     singleRow(),
+			scanThrows: true,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSql := newMockSQLReader(tt.columns, tt.values)
+			mockSql.columnsThrows = tt.columnsThrows
+			mockSql.scanThrows = tt.scanThrows
+			reader := NewFormReader(tt.form, mockSql)
+			got, err := reader.GetRecords()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type mockSqlReader struct {
+	i             int
+	columns       []string
+	values        [][]interface{}
+	columnsThrows bool
+	scanThrows    bool
+}
+
+func newMockSQLReader(columns []string, values [][]interface{}) *mockSqlReader {
+	return &mockSqlReader{
+		i:       -1,
+		columns: columns,
+		values:  values,
+	}
+}
+
+func (m *mockSqlReader) Columns() ([]string, error) {
+	if m.columnsThrows {
+		return nil, fmt.Errorf("mock error")
+	}
+	return m.columns, nil
+}
+
+func (m *mockSqlReader) Next() bool {
+	m.i = m.i + 1
+	return m.i < len(m.values)
+}
+
+func (m *mockSqlReader) Scan(intf ...interface{}) error {
+	if m.scanThrows {
+		return fmt.Errorf("mock error")
+	}
+	first := intf[0]
+	firstValue := reflect.ValueOf(first)
+	firstValue.Elem().Set(reflect.ValueOf(m.values[m.i]))
+	return nil
+}
+
+var _ sqlReader = &mockSqlReader{}
+
+type mockForm struct {
+	id         string
+	databaseId string
+	owner      types.FormInterface
+	hasOwner   bool
+	fields     []*types.FieldDefinition
+}
+
+func (m mockForm) GetFormID() string {
+	return m.id
+}
+
+func (m mockForm) GetDatabaseID() string {
+	return m.databaseId
+}
+
+func (m mockForm) GetFields() types.FieldDefinitions {
+	return m.fields
+}
+
+func (m mockForm) GetOwner() types.FormInterface {
+	return m.owner
+}
+
+func (m mockForm) HasOwner() bool {
+	return m.hasOwner
+}
+
+func (m mockForm) FindSubForm(subFormId string) (types.FormInterface, error) {
+	panic("not implemented")
+}
+
+var _ types.FormInterface = &mockForm{}

--- a/pkg/sqlmanager/formwriter.go
+++ b/pkg/sqlmanager/formwriter.go
@@ -1,0 +1,128 @@
+package sqlmanager
+
+import (
+	"errors"
+	"fmt"
+	"github.com/lib/pq"
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/sql/schema"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func NewFormWriter(form types.FormInterface) FormWriter {
+	return &formWriter{
+		form: form,
+	}
+}
+
+type FormWriter interface {
+	WriteRecords(records *types.RecordList) ([]schema.DDL, error)
+}
+
+type formWriter struct {
+	form types.FormInterface
+}
+
+func (f *formWriter) WriteRecords(records *types.RecordList) ([]schema.DDL, error) {
+	var result []schema.DDL
+	for _, item := range records.Items {
+		recordDDL, err := f.writeRecord(item)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, recordDDL)
+	}
+	return result, nil
+}
+
+func (f *formWriter) writeRecord(record *types.Record) (schema.DDL, error) {
+
+	ddl := fmt.Sprintf(`insert into %s.%s (`,
+		pq.QuoteIdentifier(f.form.GetDatabaseID()),
+		pq.QuoteIdentifier(f.form.GetFormID()),
+	)
+
+	paramCount := 1
+	columnNames := []string{keyIdColumn}
+	args := []interface{}{record.ID}
+
+	if f.form.HasOwner() {
+		if record.OwnerID == nil {
+			return schema.DDL{}, errors.New("no owner id on record")
+		}
+		paramCount++
+		args = append(args, *record.OwnerID)
+		columnNames = append(columnNames, keyOwnerIdColumn)
+	}
+
+	for _, field := range f.form.GetFields() {
+		fieldKind, err := field.FieldType.GetFieldKind()
+		if err != nil {
+			return schema.DDL{}, err
+		}
+		switch fieldKind {
+		case types.FieldKindText, types.FieldKindMultilineText, types.FieldKindReference, types.FieldKindSingleSelect:
+			if fieldValue, ok := record.Values.Find(field.ID); ok {
+				paramCount++
+				columnNames = append(columnNames, field.ID)
+				if fieldValue.Value != nil {
+					args = append(args, *fieldValue.Value)
+				} else {
+					args = append(args, nil)
+				}
+			}
+		case types.FieldKindDate, types.FieldKindMonth:
+			if fieldValue, ok := record.Values.Find(field.ID); ok {
+				paramCount++
+				columnNames = append(columnNames, field.ID)
+				if fieldValue.Value != nil {
+					var dateFormat string
+					switch fieldKind {
+					case types.FieldKindDate:
+						dateFormat = dateFieldFormat
+					case types.FieldKindMonth:
+						dateFormat = monthFieldFormat
+					}
+					sqlDate, err := time.Parse(dateFormat, *fieldValue.Value)
+					if err != nil {
+						return schema.DDL{}, err
+					}
+					args = append(args, sqlDate)
+				} else {
+					args = append(args, nil)
+				}
+			}
+		case types.FieldKindQuantity:
+			if fieldValue, ok := record.Values.Find(field.ID); ok {
+				paramCount++
+				columnNames = append(columnNames, field.ID)
+				if fieldValue.Value != nil {
+					intValue, err := strconv.Atoi(*fieldValue.Value)
+					if err != nil {
+						return schema.DDL{}, err
+					}
+					args = append(args, intValue)
+				} else {
+					args = append(args, nil)
+				}
+			}
+		}
+	}
+
+	ddl = ddl + strings.Join(columnNames, ",")
+	ddl = ddl + ") values ("
+
+	for i := 1; i <= paramCount; i++ {
+		ddl = ddl + "$" + strconv.Itoa(i)
+		if i < paramCount {
+			ddl = ddl + ","
+		}
+	}
+
+	ddl = ddl + ");"
+
+	return schema.NewDDL(ddl, args...), nil
+
+}

--- a/pkg/sqlmanager/formwriter_test.go
+++ b/pkg/sqlmanager/formwriter_test.go
@@ -1,0 +1,232 @@
+package sqlmanager
+
+import (
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/sql/schema"
+	tu "github.com/nrc-no/core/pkg/testutils"
+	"github.com/nrc-no/core/pkg/utils/pointers"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func Test_formWriter_WriteRecords(t *testing.T) {
+
+	const (
+		formId     = "formId"
+		databaseId = "databaseId"
+	)
+
+	formWithFields := func(options ...tu.FormOption) types.FormInterface {
+		opts := []tu.FormOption{
+			tu.FormID(formId),
+			tu.FormDatabaseID(databaseId),
+		}
+		f := tu.AForm(append(opts, options...)...)
+		return f
+	}
+
+	aRecord := func(options ...tu.RecordOption) *types.Record {
+		opts := []tu.RecordOption{
+			tu.RecordID("recordId"),
+			tu.RecordFormID(formId),
+			tu.RecordDatabaseID(databaseId),
+		}
+		opts = append(opts, options...)
+		return tu.RecordOptions(opts...)(&types.Record{})
+	}
+
+	aSingleRecord := func(options ...tu.RecordOption) *types.RecordList {
+		return &types.RecordList{
+			Items: []*types.Record{
+				aRecord(options...),
+			},
+		}
+	}
+
+	mustParseTime := func(layout string, str string) time.Time {
+		tm, err := time.Parse(layout, str)
+		if err != nil {
+			panic(err)
+		}
+		return tm
+	}
+
+	tests := []struct {
+		name    string
+		form    types.FormInterface
+		records *types.RecordList
+		want    []schema.DDL
+		wantErr bool
+	}{
+		{
+			name:    "record with text value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeText()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("myValue"))),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", "myValue"},
+				},
+			},
+		}, {
+			name:    "record with null text value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeText()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", nil)),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", nil},
+				},
+			},
+		}, {
+			name:    "record with multiline text value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeMultilineText()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("myValue"))),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", "myValue"},
+				},
+			},
+		}, {
+			name:    "record with nil multiline text value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeMultilineText()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", nil)),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", nil},
+				},
+			},
+		}, {
+			name:    "record with month value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeMonth()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("2020-01"))),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", mustParseTime(monthFieldFormat, "2020-01")},
+				},
+			},
+		}, {
+			name:    "record with nil month value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeMonth()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", nil)),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", nil},
+				},
+			},
+		}, {
+			name:    "record with bad month value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeMonth()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("abc"))),
+			wantErr: true,
+		}, {
+			name:    "record with date value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeDate()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("2020-01-01"))),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", mustParseTime(dateFieldFormat, "2020-01-01")},
+				},
+			},
+		}, {
+			name:    "record with nil date value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeDate()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", nil)),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", nil},
+				},
+			},
+		}, {
+			name:    "record with bad date value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeDate()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("abc"))),
+			wantErr: true,
+		}, {
+			name:    "record with reference value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeReference()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("refId"))),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", "refId"},
+				},
+			},
+		}, {
+			name:    "record with nil reference value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeReference()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", nil)),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", nil},
+				},
+			},
+		}, {
+			name:    "record with quantity value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeQuantity()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("3"))),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", 3},
+				},
+			},
+		}, {
+			name:    "record with nil quantity value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeQuantity()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", nil)),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,fieldId) values ($1,$2);`,
+					Args:  []interface{}{"recordId", nil},
+				},
+			},
+		}, {
+			name:    "record with bad quantity value",
+			form:    formWithFields(tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeQuantity()))),
+			records: aSingleRecord(tu.RecordValue("fieldId", pointers.String("abc"))),
+			wantErr: true,
+		}, {
+			name: "record with owner",
+			form: formWithFields(
+				tu.FormHasOwner(true),
+				tu.FormField(tu.AField(tu.FieldID("fieldId"), tu.FieldTypeQuantity())),
+			),
+			records: aSingleRecord(
+				tu.RecordOwnerID(pointers.String("ownerId")),
+				tu.RecordValue("fieldId", pointers.String("123")),
+			),
+			want: []schema.DDL{
+				{
+					Query: `insert into "databaseId"."formId" (id,owner_id,fieldId) values ($1,$2,$3);`,
+					Args:  []interface{}{"recordId", "ownerId", 123},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &formWriter{
+				form: tt.form,
+			}
+			got, err := f.WriteRecords(tt.records)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			if !assert.NoError(t, err) {
+				return
+			}
+			t.Log(got)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/store/record.go
+++ b/pkg/store/record.go
@@ -2,13 +2,13 @@ package store
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"github.com/lib/pq"
 	"github.com/nrc-no/core/pkg/api/meta"
 	"github.com/nrc-no/core/pkg/api/types"
-	uuid "github.com/satori/go.uuid"
+	"github.com/nrc-no/core/pkg/sqlmanager"
 	"go.uber.org/zap"
+	"gorm.io/gorm"
 	"strings"
 )
 
@@ -82,20 +82,20 @@ func (r recordStore) Get(ctx context.Context, recordRef types.RecordRef) (*types
 		return nil, meta.NewInternalServerError(err)
 	}
 
-	l.Debug("mapping records")
-	recordList, err := mapRecordList(form.GetDatabaseID(), form.GetFormID(), result)
+	formReader := sqlmanager.NewFormReader(form, result)
+	records, err := formReader.GetRecords()
 	if err != nil {
-		l.Error("failed to map records", zap.Error(err))
+		l.Error("failed to list records", zap.Error(err))
 		return nil, err
 	}
 
-	if len(recordList.Items) != 1 {
+	if len(records.Items) != 1 {
 		err := meta.NewInternalServerError(fmt.Errorf("unexpected number of records"))
 		l.Error("should only have 1 record in result", zap.Error(err))
 		return nil, err
 	}
 
-	return recordList.Items[0], nil
+	return records.Items[0], nil
 
 }
 
@@ -149,73 +149,14 @@ func (r recordStore) List(ctx context.Context, options types.RecordListOptions) 
 		return nil, meta.NewInternalServerError(err)
 	}
 
-	l.Debug("mapping records")
-	recordList, err := mapRecordList(form.GetDatabaseID(), form.GetFormID(), result)
+	formReader := sqlmanager.NewFormReader(form, result)
+	records, err := formReader.GetRecords()
 	if err != nil {
-		l.Error("failed to map records", zap.Error(err))
+		l.Error("failed to list records", zap.Error(err))
 		return nil, err
 	}
 
-	return recordList, nil
-}
-
-func mapRecordList(databaseId, formId string, result *sql.Rows) (*types.RecordList, error) {
-
-	cols, err := result.Columns()
-	if err != nil {
-		return nil, meta.NewInternalServerError(err)
-	}
-
-	var records []*types.Record
-	for result.Next() {
-		record, err := mapRecord(databaseId, formId, cols, result)
-		if err != nil {
-			return nil, err
-		}
-		records = append(records, record)
-	}
-
-	if records == nil {
-		records = []*types.Record{}
-	}
-
-	recordList := &types.RecordList{
-		Items: records,
-	}
-	return recordList, nil
-}
-
-func mapRecord(databaseId, formId string, cols []string, result *sql.Rows) (*types.Record, error) {
-	var recordValues = map[string]interface{}{}
-	if err := mapRecordRow(cols, result, recordValues); err != nil {
-		return nil, err
-	}
-
-	recordID := recordValues["id"].(string)
-	recordSeq := recordValues["seq"].(int64)
-	var ownerId *string = nil
-	if ownerIdIntf, ok := recordValues["owner_id"]; ok {
-		if ownerIdStr, ok := ownerIdIntf.(string); ok {
-			ownerId = &ownerIdStr
-		}
-	}
-
-	delete(recordValues, "id")
-	delete(recordValues, "seq")
-	delete(recordValues, "database_id")
-	delete(recordValues, "form_id")
-	delete(recordValues, "owner_id")
-	delete(recordValues, "created_at")
-
-	record := &types.Record{
-		ID:         recordID,
-		Seq:        recordSeq,
-		DatabaseID: databaseId,
-		FormID:     formId,
-		OwnerID:    ownerId,
-		Values:     recordValues,
-	}
-	return record, nil
+	return records, nil
 }
 
 func (r recordStore) Create(ctx context.Context, record *types.Record) (*types.Record, error) {
@@ -225,18 +166,12 @@ func (r recordStore) Create(ctx context.Context, record *types.Record) (*types.R
 	}
 	defer done()
 
-	var keys []string
-	var values []interface{}
-	var params []string
-	i := 1
-
-	l.Debug("getting root form")
+	l.Debug("getting record form")
 	rootForm, err := r.formStore.Get(ctx, record.FormID)
 	if err != nil {
-		l.Error("failed to get record root form", zap.Error(err))
+		l.Error("failed to get record form")
 		return nil, err
 	}
-	databaseId := rootForm.DatabaseID
 
 	l.Debug("getting form interface")
 	form, err := rootForm.GetFormOrSubForm(record.FormID)
@@ -245,54 +180,25 @@ func (r recordStore) Create(ctx context.Context, record *types.Record) (*types.R
 		return nil, meta.NewInternalServerError(err)
 	}
 
-	record.ID = uuid.NewV4().String()
+	formWriter := sqlmanager.NewFormWriter(form)
+	ddl, err := formWriter.WriteRecords(&types.RecordList{
+		Items: []*types.Record{record},
+	})
 
-	for _, field := range form.GetFields() {
-		if fieldValue, ok := record.Values[field.ID]; ok {
-			keys = append(keys, pq.QuoteIdentifier(field.ID))
-			values = append(values, fieldValue)
-			params = append(params, fmt.Sprintf("$%d", i))
-			i++
+	err = db.Transaction(func(tx *gorm.DB) error {
+		for _, ddlItem := range ddl {
+			if err := tx.Exec(ddlItem.Query, ddlItem.Args...).Error; err != nil {
+				return err
+			}
 		}
-	}
-
-	keys = append(keys, "id")
-	values = append(values, record.ID)
-	params = append(params, fmt.Sprintf("$%d", i))
-	i++
-
-	if record.OwnerID != nil {
-		keys = append(keys, "owner_id")
-		values = append(values, record.OwnerID)
-		params = append(params, fmt.Sprintf("$%d", i))
-		i++
-	}
-
-	insertQry := strings.Builder{}
-	insertQry.WriteString(fmt.Sprintf("insert into %s.%s (%s) values (%s) returning id",
-		pq.QuoteIdentifier(databaseId),
-		pq.QuoteIdentifier(form.GetFormID()),
-		strings.Join(keys, ","),
-		strings.Join(params, ","),
-	))
-
-	l.Debug("getting raw sql database")
-	sqlDB, err := db.DB()
+		return nil
+	})
 	if err != nil {
-		l.Error("failed to get raw sql database", zap.Error(err))
-		return nil, meta.NewInternalServerError(err)
-	}
-
-	l.Debug("inserting record")
-	var lastInsertedId string
-	insertSQLQuery := insertQry.String()
-	if err := sqlDB.QueryRow(insertSQLQuery, values...).Scan(&lastInsertedId); err != nil {
-		l.Error("failed to insert record", zap.Error(err))
-		return nil, meta.NewInternalServerError(err)
+		return nil, err
 	}
 
 	return r.Get(ctx, types.RecordRef{
-		ID:         lastInsertedId,
+		ID:         record.ID,
 		DatabaseID: record.DatabaseID,
 		FormID:     record.FormID,
 	})
@@ -307,28 +213,3 @@ func (r recordStore) Delete(ctx context.Context, recordRef types.RecordRef) erro
 }
 
 var _ RecordStore = &recordStore{}
-
-func mapRecordRow(cols []string, rows *sql.Rows, into map[string]interface{}) error {
-
-	cols, err := rows.Columns()
-	if err != nil {
-		return meta.NewInternalServerError(err)
-	}
-
-	dest := make([]interface{}, len(cols))
-	args := make([]interface{}, len(cols))
-
-	for i := range cols {
-		args[i] = &(dest[i])
-	}
-
-	if err := rows.Scan(args...); err != nil {
-		return meta.NewInternalServerError(err)
-	}
-
-	for i, col := range cols {
-		into[col] = dest[i]
-	}
-
-	return nil
-}

--- a/pkg/testutils/options.go
+++ b/pkg/testutils/options.go
@@ -1,0 +1,367 @@
+package testutils
+
+import (
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/utils/pointers"
+	"github.com/satori/go.uuid"
+)
+
+type RecordOption func(record *types.Record) *types.Record
+
+func RecordOptions(options ...RecordOption) RecordOption {
+	return func(record *types.Record) *types.Record {
+		r := record
+		for _, option := range options {
+			r = option(r)
+		}
+		return r
+	}
+}
+
+func RecordID(recordId string) RecordOption {
+	return func(record *types.Record) *types.Record {
+		record.ID = recordId
+		return record
+	}
+}
+
+func RecordFormID(formID string) RecordOption {
+	return func(record *types.Record) *types.Record {
+		record.FormID = formID
+		return record
+	}
+}
+
+func RecordDatabaseID(databaseID string) RecordOption {
+	return func(record *types.Record) *types.Record {
+		record.DatabaseID = databaseID
+		return record
+	}
+}
+
+func RecordOwnerID(ownerID *string) RecordOption {
+	return func(record *types.Record) *types.Record {
+		record.OwnerID = ownerID
+		return record
+	}
+}
+
+func RecordValues(values types.FieldValues) RecordOption {
+	return func(record *types.Record) *types.Record {
+
+		if values == nil {
+			record.Values = nil
+			return record
+		}
+
+		var v = types.FieldValues{}
+		for _, value := range values {
+			v = append(v, value)
+		}
+		record.Values = v
+		return record
+	}
+}
+
+func RecordValue(fieldID string, value *string) RecordOption {
+	return func(record *types.Record) *types.Record {
+		val := types.FieldValue{
+			FieldID: fieldID,
+			Value:   value,
+		}
+		for i, fieldValue := range record.Values {
+			if fieldValue.FieldID == fieldID {
+				record.Values[i] = val
+				return record
+			}
+		}
+		record.Values = append(record.Values, val)
+		return record
+	}
+}
+func RecordOmitValue(fieldID string) RecordOption {
+	return func(record *types.Record) *types.Record {
+		res := types.FieldValues{}
+		for _, value := range record.Values {
+			if value.FieldID != fieldID {
+				res = append(res, value)
+			}
+		}
+		record.Values = res
+		return record
+	}
+}
+
+func ARecord(options ...RecordOption) *types.Record {
+	r := &types.Record{}
+	for _, option := range options {
+		r = option(r)
+	}
+	return r
+}
+
+type mockForm struct {
+	formId        string
+	databaseId    string
+	fields        types.FieldDefinitions
+	owner         types.FormInterface
+	hasOwner      bool
+	findSubFormFn func() (types.FormInterface, error)
+}
+
+func (m mockForm) GetFormID() string {
+	return m.formId
+}
+
+func (m mockForm) GetDatabaseID() string {
+	return m.databaseId
+}
+
+func (m mockForm) GetFields() types.FieldDefinitions {
+	return m.fields
+}
+
+func (m mockForm) GetOwner() types.FormInterface {
+	return m.owner
+}
+
+func (m mockForm) HasOwner() bool {
+	return m.hasOwner
+}
+
+func (m mockForm) FindSubForm(subFormId string) (types.FormInterface, error) {
+	return m.findSubFormFn()
+}
+
+var _ types.FormInterface = &mockForm{}
+
+type FormOption func(form *mockForm) *mockForm
+
+func FormOptions(options ...FormOption) FormOption {
+	return func(form *mockForm) *mockForm {
+		walk := form
+		for _, option := range options {
+			walk = option(walk)
+		}
+		return walk
+	}
+}
+
+func FormID(id string) FormOption {
+	return func(form *mockForm) *mockForm {
+		form.formId = id
+		return form
+	}
+}
+
+func FormDatabaseID(databaseId string) FormOption {
+	return func(form *mockForm) *mockForm {
+		form.databaseId = databaseId
+		return form
+	}
+}
+
+func FormHasOwner(hasOwner bool) FormOption {
+	return func(form *mockForm) *mockForm {
+		form.hasOwner = hasOwner
+		return form
+	}
+}
+
+func FormOwner(owner types.FormInterface) FormOption {
+	return func(form *mockForm) *mockForm {
+		form.owner = owner
+		return form
+	}
+}
+
+func FormField(field *types.FieldDefinition) FormOption {
+	return func(form *mockForm) *mockForm {
+		form.fields = append(form.fields, field)
+		return form
+	}
+}
+
+func FormFields(fields ...*types.FieldDefinition) FormOption {
+	return func(form *mockForm) *mockForm {
+		form.fields = fields
+		return form
+	}
+}
+
+func AForm(options ...FormOption) *mockForm {
+	r := &mockForm{}
+	for _, option := range options {
+		r = option(r)
+	}
+	return r
+}
+
+type FieldOption func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition
+
+func FieldID(fieldID string) FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.ID = fieldID
+		return fieldDefinition
+	}
+}
+
+func FieldName(fieldName string) FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.Name = fieldName
+		return fieldDefinition
+	}
+}
+
+func FieldTypeText() FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.FieldType = types.FieldType{
+			Text: &types.FieldTypeText{},
+		}
+		return fieldDefinition
+	}
+}
+
+func FieldTypeKind(kind types.FieldKind) FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		switch kind {
+		case types.FieldKindUnknown:
+			fieldDefinition.FieldType = types.FieldType{}
+		case types.FieldKindText:
+			return FieldTypeText()(fieldDefinition)
+		case types.FieldKindSubForm:
+		case types.FieldKindReference:
+			return FieldTypeReference()(fieldDefinition)
+		case types.FieldKindMultilineText:
+			return FieldTypeMultilineText()(fieldDefinition)
+		case types.FieldKindDate:
+			return FieldTypeDate()(fieldDefinition)
+		case types.FieldKindQuantity:
+			return FieldTypeQuantity()(fieldDefinition)
+		case types.FieldKindMonth:
+			return FieldTypeMonth()(fieldDefinition)
+		case types.FieldKindSingleSelect:
+			// todo
+		}
+		return fieldDefinition
+	}
+}
+
+func FieldTypeQuantity() FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.FieldType = types.FieldType{
+			Quantity: &types.FieldTypeQuantity{},
+		}
+		return fieldDefinition
+	}
+}
+
+func FieldRequired(required bool) FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.Required = required
+		return fieldDefinition
+	}
+}
+
+func FieldTypeMultilineText() FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.FieldType = types.FieldType{
+			MultilineText: &types.FieldTypeMultilineText{},
+		}
+		return fieldDefinition
+	}
+}
+
+func FieldTypeDate() FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.FieldType = types.FieldType{
+			Date: &types.FieldTypeDate{},
+		}
+		return fieldDefinition
+	}
+}
+
+func FieldTypeReference() FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.FieldType = types.FieldType{
+			Reference: &types.FieldTypeReference{
+				DatabaseID: uuid.NewV4().String(),
+				FormID:     uuid.NewV4().String(),
+			},
+		}
+		return fieldDefinition
+	}
+}
+
+func FieldTypeMonth() FieldOption {
+	return func(fieldDefinition *types.FieldDefinition) *types.FieldDefinition {
+		fieldDefinition.FieldType = types.FieldType{
+			Month: &types.FieldTypeMonth{},
+		}
+		return fieldDefinition
+	}
+}
+
+func AField(options ...FieldOption) *types.FieldDefinition {
+	f := &types.FieldDefinition{}
+	for _, option := range options {
+		f = option(f)
+	}
+	return f
+}
+
+func RecordForForm(form types.FormInterface) RecordOption {
+	return func(r *types.Record) *types.Record {
+		r.ID = uuid.NewV4().String()
+		r.FormID = form.GetFormID()
+		r.DatabaseID = form.GetDatabaseID()
+		if r.Values == nil {
+			r.Values = types.FieldValues{}
+		}
+		if form.HasOwner() {
+			r.OwnerID = pointers.String(uuid.NewV4().String())
+		}
+		for _, field := range form.GetFields() {
+			if field.FieldType.Date != nil {
+				r.Values = append(r.Values, types.FieldValue{
+					FieldID: field.ID,
+					Value:   pointers.String("2020-01-01"),
+				})
+			} else if field.FieldType.Month != nil {
+				r.Values = append(r.Values, types.FieldValue{
+					FieldID: field.ID,
+					Value:   pointers.String("2020-01"),
+				})
+			} else if field.FieldType.Text != nil {
+				r.Values = append(r.Values, types.FieldValue{
+					FieldID: field.ID,
+					Value:   pointers.String("abc"),
+				})
+			} else if field.FieldType.MultilineText != nil {
+				r.Values = append(r.Values, types.FieldValue{
+					FieldID: field.ID,
+					Value:   pointers.String("abc\ndef"),
+				})
+			} else if field.FieldType.Reference != nil {
+				r.Values = append(r.Values, types.FieldValue{
+					FieldID: field.ID,
+					Value:   pointers.String(uuid.NewV4().String()),
+				})
+			} else if field.FieldType.Quantity != nil {
+				r.Values = append(r.Values, types.FieldValue{
+					FieldID: field.ID,
+					Value:   pointers.String("10"),
+				})
+			}
+		}
+		return r
+	}
+}
+
+func ARecordForForm(form types.FormInterface, options ...RecordOption) *types.Record {
+	opts := []RecordOption{
+		RecordForForm(form),
+	}
+	opts = append(opts, options...)
+	return ARecord(opts...)
+}

--- a/pkg/utils/pointers/pointers.go
+++ b/pkg/utils/pointers/pointers.go
@@ -1,5 +1,7 @@
 package pointers
 
+import "time"
+
 func Int(val int) *int {
 	return &val
 }
@@ -13,5 +15,9 @@ func Int32(val int32) *int32 {
 }
 
 func String(val string) *string {
+	return &val
+}
+
+func Time(val time.Time) *time.Time {
 	return &val
 }

--- a/web/app/client/src/lib/types/index.ts
+++ b/web/app/client/src/lib/types/index.ts
@@ -59,6 +59,7 @@ export type FieldDefinition = {
     description: string
     required: boolean
     key: boolean
+    options: string[]
     fieldType: FieldType
 }
 

--- a/web/app/client/src/lib/types/index.ts
+++ b/web/app/client/src/lib/types/index.ts
@@ -1,12 +1,12 @@
 import {AxiosInstance} from "axios";
 
-export class Database {
-    public id: string = ""
-    public name: string = ""
+export type Database = {
+    id: string
+    name: string
 }
 
-export class DatabaseList {
-    public items: Database[] = []
+export type DatabaseList = {
+    items: Database[]
 }
 
 export enum FieldKind {
@@ -20,89 +20,87 @@ export enum FieldKind {
     Month = "month"
 }
 
-export class FieldType {
-    public text?: FieldTypeText
-    public reference?: FieldTypeReference
-    public subForm?: FieldTypeSubForm
-    public multilineText?: FieldTypeMultilineText
-    public date?: FieldTypeDate
-    public month?: FieldTypeMonth
-    public quantity?: FieldTypeQuantity
-    public singleSelect?: FieldTypeSingleSelect
+export type FieldType = {
+    text?: FieldTypeText
+    reference?: FieldTypeReference
+    subForm?: FieldTypeSubForm
+    multilineText?: FieldTypeMultilineText
+    date?: FieldTypeDate
+    month?: FieldTypeMonth
+    quantity?: FieldTypeQuantity
+    singleSelect?: FieldTypeSingleSelect
 }
 
-export class FieldTypeText {
+export type FieldTypeText = {}
+
+export type FieldTypeMultilineText = {}
+
+export type FieldTypeDate = {}
+
+export type FieldTypeMonth = {}
+
+export type FieldTypeQuantity = {}
+
+export type FieldTypeSingleSelect = {}
+
+export type FieldTypeReference = {
+    databaseId: string
+    formId: string
 }
 
-export class FieldTypeMultilineText {
+export type FieldTypeSubForm = {
+    fields: FieldDefinition[]
 }
 
-export class FieldTypeDate {
+export type FieldDefinition = {
+    id: string
+    code: string
+    name: string
+    description: string
+    required: boolean
+    key: boolean
+    fieldType: FieldType
 }
 
-export class FieldTypeMonth {
+export type FormDefinition = {
+    id: string
+    code: string
+    databaseId: string
+    folderId: string
+    name: string
+    fields: FieldDefinition[]
 }
 
-export class FieldTypeQuantity {
+export type FormDefinitionList = {
+    items: FormDefinition[]
 }
 
-export class FieldTypeSingleSelect {
+export type Folder = {
+    id: string
+    databaseId: string
+    parentId: string
+    name: string
 }
 
-export class FieldTypeReference {
-    public databaseId: string = ""
-    public formId: string = ""
+export type FolderList = {
+    items: Folder[]
 }
 
-export class FieldTypeSubForm {
-    public fields: FieldDefinition[] = []
+export type FieldValue = {
+    fieldId: string
+    value: string
 }
 
-export class FieldDefinition {
-    public id: string = ""
-    public code: string = ""
-    public name: string = ""
-    public description: string = ""
-    public required: boolean = false
-    public options: string[] = []
-    public key: boolean = false
-    public fieldType: FieldType = new FieldType()
+export type Record = {
+    id: string
+    databaseId: string
+    formId: string
+    ownerId: string | undefined
+    values: FieldValue[]
 }
 
-export class FormDefinition {
-    public id: string = ""
-    public code: string = ""
-    public databaseId: string = ""
-    public folderId: string = ""
-    public name: string = ""
-    public fields: FieldDefinition[] = []
-}
-
-export class FormDefinitionList {
-    public items: FormDefinition[] = []
-}
-
-export class Folder {
-    public id: string = ""
-    public databaseId: string = ""
-    public parentId: string = ""
-    public name: string = ""
-}
-
-export class FolderList {
-    public items: Folder[] = []
-}
-
-export class Record {
-    public id: string = ""
-    public databaseId: string = ""
-    public formId: string = ""
-    public ownerId: string | undefined = undefined
-    public values: { [key: string]: any } = {}
-}
-
-export class LocalRecord extends Record {
-    public isNew: boolean = false
+export type LocalRecord = Record & {
+    isNew: boolean
 }
 
 export type RecordList = { items: Record[] }

--- a/web/app/frontend/yarn.lock
+++ b/web/app/frontend/yarn.lock
@@ -1764,7 +1764,7 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
-"@isaacs/string-locale-compare@*", "@isaacs/string-locale-compare@^1.1.0":
+"@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"
   integrity sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==
@@ -2026,7 +2026,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@npmcli/arborist@*", "@npmcli/arborist@^4.0.0":
+"@npmcli/arborist@^4.0.0", "@npmcli/arborist@^4.0.5":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@npmcli/arborist/-/arborist-4.1.0.tgz#436464664bcfb3b180963383c410ff9180351c59"
   integrity sha512-bkaOqCuTUtpVOe1vaAP7TUihu64wIbnSDpsbqBJUsGFTLYXbjKwi6xj8Zx5cfHkM3nqyeEEbPYlGkt0TXjKrUg==
@@ -2064,12 +2064,12 @@
     treeverse "^1.0.4"
     walk-up-path "^1.0.0"
 
-"@npmcli/ci-detect@*", "@npmcli/ci-detect@^1.3.0":
+"@npmcli/ci-detect@^1.3.0", "@npmcli/ci-detect@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@npmcli/ci-detect/-/ci-detect-1.4.0.tgz#18478bbaa900c37bfbd8a2006a6262c62e8b0fe1"
   integrity sha512-3BGrt6FLjqM6br5AhWRKTr3u5GIVkjRYeAFrMp3HjnfICrg4xOrVRwFavKT6tsp++bq5dluL5t8ME/Nha/6c1Q==
 
-"@npmcli/config@*":
+"@npmcli/config@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@npmcli/config/-/config-2.3.2.tgz#6027efc132fcc809abef749c2f2e13dc4dcd6e0b"
   integrity sha512-2/9dj143BFgQR8qxJbYptd8k+4+Po2uHYq3H6498ynZcRu4LrsDlngov5HGrvo2+f0pe0fBJwDEP2rRtaW8bkw==
@@ -2117,7 +2117,7 @@
     npm-bundled "^1.1.1"
     npm-normalize-package-bin "^1.0.1"
 
-"@npmcli/map-workspaces@*", "@npmcli/map-workspaces@^2.0.0":
+"@npmcli/map-workspaces@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@npmcli/map-workspaces/-/map-workspaces-2.0.0.tgz#e342efbbdd0dad1bba5d7723b674ca668bf8ac5a"
   integrity sha512-QBJfpCY1NOAkkW3lFfru9VTdqvMB2TN0/vrevl5xBCv5Fi0XDVcA6rqqSau4Ysi4Iw3fBzyXV7hzyTBDfadf7g==
@@ -2155,7 +2155,7 @@
   resolved "https://registry.yarnpkg.com/@npmcli/node-gyp/-/node-gyp-1.0.3.tgz#a912e637418ffc5f2db375e93b85837691a43a33"
   integrity sha512-fnkhw+fmX65kiLqk6E3BFLXNC26rUhK90zVwe2yncPliVT/Qos3xjhTLE59Df8KnPlcwIERXKVlU1bXoUQ+liA==
 
-"@npmcli/package-json@*", "@npmcli/package-json@^1.0.1":
+"@npmcli/package-json@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@npmcli/package-json/-/package-json-1.0.1.tgz#1ed42f00febe5293c3502fd0ef785647355f6e89"
   integrity sha512-y6jnu76E9C23osz8gEMBayZmaZ69vFOIk8vR1FJL/wbEJ54+9aVG9rLTjQKSXfgYZEr50nw1txBBFfBZZe+bYg==
@@ -2169,16 +2169,6 @@
   dependencies:
     infer-owner "^1.0.4"
 
-"@npmcli/run-script@*", "@npmcli/run-script@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-2.0.0.tgz#9949c0cab415b17aaac279646db4f027d6f1e743"
-  integrity sha512-fSan/Pu11xS/TdaTpTB0MRn9guwGU8dye+x56mEVgBEd/QsybBbYcAL0phPXi8SGWFEChkQd6M9qL4y6VOpFig==
-  dependencies:
-    "@npmcli/node-gyp" "^1.0.2"
-    "@npmcli/promise-spawn" "^1.3.2"
-    node-gyp "^8.2.0"
-    read-package-json-fast "^2.0.1"
-
 "@npmcli/run-script@^1.8.2":
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-1.8.6.tgz#18314802a6660b0d4baa4c3afe7f1ad39d8c28b7"
@@ -2187,6 +2177,16 @@
     "@npmcli/node-gyp" "^1.0.2"
     "@npmcli/promise-spawn" "^1.3.2"
     node-gyp "^7.1.0"
+    read-package-json-fast "^2.0.1"
+
+"@npmcli/run-script@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-2.0.0.tgz#9949c0cab415b17aaac279646db4f027d6f1e743"
+  integrity sha512-fSan/Pu11xS/TdaTpTB0MRn9guwGU8dye+x56mEVgBEd/QsybBbYcAL0phPXi8SGWFEChkQd6M9qL4y6VOpFig==
+  dependencies:
+    "@npmcli/node-gyp" "^1.0.2"
+    "@npmcli/promise-spawn" "^1.3.2"
+    node-gyp "^8.2.0"
     read-package-json-fast "^2.0.1"
 
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
@@ -3915,7 +3915,7 @@ abab@^2.0.3, abab@^2.0.5:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
   integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
-abbrev@*, abbrev@1:
+abbrev@1, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
@@ -4115,12 +4115,12 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansicolors@*:
+ansicolors@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
   integrity sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=
 
-ansistyles@*:
+ansistyles@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
   integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
@@ -4161,7 +4161,7 @@ aproba@^1.0.3, aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-archy@*:
+archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
@@ -5049,7 +5049,28 @@ bytes@3.1.0:
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
-cacache@*, cacache@^15.0.3, cacache@^15.0.5, cacache@^15.2.0:
+cacache@^12.0.2:
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c"
+  integrity sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==
+  dependencies:
+    bluebird "^3.5.5"
+    chownr "^1.1.1"
+    figgy-pudding "^3.5.1"
+    glob "^7.1.4"
+    graceful-fs "^4.1.15"
+    infer-owner "^1.0.3"
+    lru-cache "^5.1.1"
+    mississippi "^3.0.0"
+    mkdirp "^0.5.1"
+    move-concurrently "^1.0.1"
+    promise-inflight "^1.0.1"
+    rimraf "^2.6.3"
+    ssri "^6.0.1"
+    unique-filename "^1.1.1"
+    y18n "^4.0.0"
+
+cacache@^15.0.3, cacache@^15.0.5, cacache@^15.2.0, cacache@^15.3.0:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.3.0.tgz#dc85380fb2f556fe3dda4c719bfa0ec875a7f1eb"
   integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
@@ -5072,27 +5093,6 @@ cacache@*, cacache@^15.0.3, cacache@^15.0.5, cacache@^15.2.0:
     ssri "^8.0.1"
     tar "^6.0.2"
     unique-filename "^1.1.1"
-
-cacache@^12.0.2:
-  version "12.0.4"
-  resolved "https://registry.yarnpkg.com/cacache/-/cacache-12.0.4.tgz#668bcbd105aeb5f1d92fe25570ec9525c8faa40c"
-  integrity sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==
-  dependencies:
-    bluebird "^3.5.5"
-    chownr "^1.1.1"
-    figgy-pudding "^3.5.1"
-    glob "^7.1.4"
-    graceful-fs "^4.1.15"
-    infer-owner "^1.0.3"
-    lru-cache "^5.1.1"
-    mississippi "^3.0.0"
-    mkdirp "^0.5.1"
-    move-concurrently "^1.0.1"
-    promise-inflight "^1.0.1"
-    rimraf "^2.6.3"
-    ssri "^6.0.1"
-    unique-filename "^1.1.1"
-    y18n "^4.0.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -5191,11 +5191,6 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@*:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
-  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
-
 chalk@2.4.2, chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -5265,15 +5260,15 @@ chokidar@^3.4.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chownr@*, chownr@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
-  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"
@@ -5332,7 +5327,7 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
   integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
-cli-columns@*:
+cli-columns@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/cli-columns/-/cli-columns-4.0.0.tgz#9fe4d65975238d55218c41bd2ed296a7fa555646"
   integrity sha512-XW2Vg+w+L9on9wtwKpyzluIPCWXjaBahI7mTcYjx+BVIYD9c3yqcv/yKC7CmdCZat4rq2yiE1UMSJC5ivKfMtQ==
@@ -5352,7 +5347,7 @@ cli-spinners@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.6.1.tgz#adc954ebe281c37a6319bfa401e6dd2488ffb70d"
   integrity sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==
 
-cli-table3@*:
+cli-table3@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
   integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
@@ -5493,7 +5488,7 @@ colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-columnify@*:
+columnify@~1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/columnify/-/columnify-1.5.4.tgz#4737ddf1c7b69a8a7c340570782e947eec8e78bb"
   integrity sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=
@@ -7605,7 +7600,7 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
-fastest-levenshtein@*:
+fastest-levenshtein@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
   integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
@@ -8113,10 +8108,10 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob@*, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -8125,10 +8120,10 @@ glob@*, glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@7.1.6:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -8200,7 +8195,7 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@*, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.3, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.8:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
@@ -8371,17 +8366,17 @@ hoopy@^0.1.4:
   resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
   integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
-hosted-git-info@*, hosted-git-info@^4.0.1:
+hosted-git-info@^2.1.4:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
+
+hosted-git-info@^4.0.1, hosted-git-info@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-4.0.2.tgz#5e425507eede4fea846b7262f0838456c4209961"
   integrity sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==
   dependencies:
     lru-cache "^6.0.0"
-
-hosted-git-info@^2.1.4:
-  version "2.8.9"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
-  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -8738,17 +8733,17 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@*, ini@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
-  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
-
 ini@^1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-init-package-json@*:
+ini@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
+init-package-json@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-2.0.5.tgz#78b85f3c36014db42d8f32117252504f68022646"
   integrity sha512-u1uGAtEFu3VA6HNl/yUWw57jmKEMx8SKOxHhxjGnOFUiIlFnohKDFg4ZrPpv9wWqk44nDxGJAtqjdQFm+9XXQA==
@@ -8920,7 +8915,7 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-cidr@*:
+is-cidr@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/is-cidr/-/is-cidr-4.0.2.tgz#94c7585e4c6c77ceabf920f8cde51b8c0fda8814"
   integrity sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==
@@ -10009,7 +10004,7 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
-json-parse-even-better-errors@*, json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
+json-parse-even-better-errors@^2.3.0, json-parse-even-better-errors@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
@@ -10216,7 +10211,7 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libnpmaccess@*:
+libnpmaccess@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-4.0.3.tgz#dfb0e5b0a53c315a2610d300e46b4ddeb66e7eec"
   integrity sha512-sPeTSNImksm8O2b6/pf3ikv4N567ERYEpeKRPSmqlNt1dTZbvgpJIzg5vAhXHpw2ISBsELFRelk0jEahj1c6nQ==
@@ -10226,7 +10221,7 @@ libnpmaccess@*:
     npm-package-arg "^8.1.2"
     npm-registry-fetch "^11.0.0"
 
-libnpmdiff@*:
+libnpmdiff@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/libnpmdiff/-/libnpmdiff-2.0.4.tgz#bb1687992b1a97a8ea4a32f58ad7c7f92de53b74"
   integrity sha512-q3zWePOJLHwsLEUjZw3Kyu/MJMYfl4tWCg78Vl6QGSfm4aXBUSVzMzjJ6jGiyarsT4d+1NH4B1gxfs62/+y9iQ==
@@ -10240,7 +10235,7 @@ libnpmdiff@*:
     pacote "^11.3.0"
     tar "^6.1.0"
 
-libnpmexec@*:
+libnpmexec@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/libnpmexec/-/libnpmexec-3.0.1.tgz#bc2fddf1b7bd2c1b2c43b4b726ec4cf11920ad0a"
   integrity sha512-VUZTpkKBRPv3Z9DIjbsiHhEQXmQ+OwSQ/yLCY9i6CFE8UIczWyE6wVxP5sJ5NSGtSTUs6I98WewQOL45OKMyxA==
@@ -10257,14 +10252,14 @@ libnpmexec@*:
     read-package-json-fast "^2.0.2"
     walk-up-path "^1.0.0"
 
-libnpmfund@*:
+libnpmfund@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/libnpmfund/-/libnpmfund-2.0.1.tgz#3c7e2be61e8c79e22c4918dde91ef57f64faf064"
   integrity sha512-OhDbjB3gqdRyuQ56AhUtO49HZ7cZHSM7yCnhQa1lsNpmAmGPnjCImfx8SoWaAkUM7Ov8jngMR5JHKAr1ddjHTQ==
   dependencies:
     "@npmcli/arborist" "^4.0.0"
 
-libnpmhook@*:
+libnpmhook@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/libnpmhook/-/libnpmhook-6.0.3.tgz#1d7f0d7e6a7932fbf7ce0881fdb0ed8bf8748a30"
   integrity sha512-3fmkZJibIybzmAvxJ65PeV3NzRc0m4xmYt6scui5msocThbEp4sKFT80FhgrCERYDjlUuFahU6zFNbJDHbQ++g==
@@ -10272,7 +10267,7 @@ libnpmhook@*:
     aproba "^2.0.0"
     npm-registry-fetch "^11.0.0"
 
-libnpmorg@*:
+libnpmorg@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-2.0.3.tgz#4e605d4113dfa16792d75343824a0625c76703bc"
   integrity sha512-JSGl3HFeiRFUZOUlGdiNcUZOsUqkSYrg6KMzvPZ1WVZ478i47OnKSS0vkPmX45Pai5mTKuwIqBMcGWG7O8HfdA==
@@ -10280,7 +10275,7 @@ libnpmorg@*:
     aproba "^2.0.0"
     npm-registry-fetch "^11.0.0"
 
-libnpmpack@*:
+libnpmpack@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/libnpmpack/-/libnpmpack-3.0.0.tgz#b1cdf182106bc0d25910e79bb5c9b6c23cd71670"
   integrity sha512-W6lt4blkR9YXu/qOrFknfnKBajz/1GvAc5q1XcWTGuBJn2DYKDWHtA7x1fuMQdn7hKDBOPlZ/Aqll+ZvAnrM6g==
@@ -10289,7 +10284,7 @@ libnpmpack@*:
     npm-package-arg "^8.1.0"
     pacote "^12.0.0"
 
-libnpmpublish@*:
+libnpmpublish@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-4.0.2.tgz#be77e8bf5956131bcb45e3caa6b96a842dec0794"
   integrity sha512-+AD7A2zbVeGRCFI2aO//oUmapCwy7GHqPXFJh3qpToSRNU+tXKJ2YFUgjt04LPPAf2dlEH95s6EhIHM1J7bmOw==
@@ -10300,14 +10295,14 @@ libnpmpublish@*:
     semver "^7.1.3"
     ssri "^8.0.1"
 
-libnpmsearch@*:
+libnpmsearch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-3.1.2.tgz#aee81b9e4768750d842b627a3051abc89fdc15f3"
   integrity sha512-BaQHBjMNnsPYk3Bl6AiOeVuFgp72jviShNBw5aHaHNKWqZxNi38iVNoXbo6bG/Ccc/m1To8s0GtMdtn6xZ1HAw==
   dependencies:
     npm-registry-fetch "^11.0.0"
 
-libnpmteam@*:
+libnpmteam@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-2.0.4.tgz#9dbe2e18ae3cb97551ec07d2a2daf9944f3edc4c"
   integrity sha512-FPrVJWv820FZFXaflAEVTLRWZrerCvfe7ZHSMzJ/62EBlho2KFlYKjyNEsPW3JiV7TLSXi3vo8u0gMwIkXSMTw==
@@ -10315,7 +10310,7 @@ libnpmteam@*:
     aproba "^2.0.0"
     npm-registry-fetch "^11.0.0"
 
-libnpmversion@*:
+libnpmversion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/libnpmversion/-/libnpmversion-2.0.1.tgz#20b1425d88cd99c66806a54b458d2d654066b550"
   integrity sha512-uFGtNTe/m0GOIBQCE4ryIsgGNJdeShW+qvYtKNLCCuiG7JY3YEslL/maFFZbaO4wlQa/oj1t0Bm9TyjahvtgQQ==
@@ -10588,7 +10583,7 @@ make-dir@^3.0.0, make-dir@^3.0.2:
   dependencies:
     semver "^6.0.0"
 
-make-fetch-happen@*, make-fetch-happen@^9.0.1, make-fetch-happen@^9.1.0:
+make-fetch-happen@^9.0.1, make-fetch-happen@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz#53085a09e7971433e6765f7971bf63f4e05cb968"
   integrity sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==
@@ -11189,7 +11184,7 @@ minipass-json-stream@^1.0.1:
     jsonparse "^1.3.1"
     minipass "^3.0.0"
 
-minipass-pipeline@*, minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
+minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz#68472f79711c084657c067c5c6ad93cddea8214c"
   integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
@@ -11203,7 +11198,7 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@*, minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
+minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
   integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
@@ -11242,7 +11237,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp-infer-owner@*, mkdirp-infer-owner@^2.0.0:
+mkdirp-infer-owner@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz#55d3b368e7d89065c38f32fd38e638f0ab61d316"
   integrity sha512-sdqtiFt3lkOaYvTXSRIUjkIdPTcxgv5+fgqYE/5qgwdw12cOrAuzzgzvVExIkH/ul1oeHN3bCLOWSG3XOqbKKw==
@@ -11251,17 +11246,17 @@ mkdirp-infer-owner@*, mkdirp-infer-owner@^2.0.0:
     infer-owner "^1.0.4"
     mkdirp "^1.0.3"
 
-mkdirp@*, mkdirp@^1.0.3, mkdirp@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
 mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
   dependencies:
     minimist "^1.2.5"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mockdate@^3.0.2:
   version "3.0.5"
@@ -11280,11 +11275,6 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-ms@*, ms@^2.0.0, ms@^2.1.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
-  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -11299,6 +11289,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.0.0, ms@^2.1.1, ms@^2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 multicast-dns-service-types@^1.1.0:
   version "1.1.0"
@@ -11471,22 +11466,6 @@ node-forge@^0.10.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-gyp@*, node-gyp@^8.2.0:
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
-  integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
-  dependencies:
-    env-paths "^2.2.0"
-    glob "^7.1.4"
-    graceful-fs "^4.2.6"
-    make-fetch-happen "^9.1.0"
-    nopt "^5.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
-    semver "^7.3.5"
-    tar "^6.1.2"
-    which "^2.0.2"
-
 node-gyp@^7.1.0:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-7.1.2.tgz#21a810aebb187120251c3bcec979af1587b188ae"
@@ -11501,6 +11480,22 @@ node-gyp@^7.1.0:
     rimraf "^3.0.2"
     semver "^7.3.2"
     tar "^6.0.2"
+    which "^2.0.2"
+
+node-gyp@^8.2.0, node-gyp@^8.4.1:
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-8.4.1.tgz#3d49308fc31f768180957d6b5746845fbd429937"
+  integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
+  dependencies:
+    env-paths "^2.2.0"
+    glob "^7.1.4"
+    graceful-fs "^4.2.6"
+    make-fetch-happen "^9.1.0"
+    nopt "^5.0.0"
+    npmlog "^6.0.0"
+    rimraf "^3.0.2"
+    semver "^7.3.5"
+    tar "^6.1.2"
     which "^2.0.2"
 
 node-int64@^0.4.0:
@@ -11569,7 +11564,7 @@ node-stream-zip@^1.9.1:
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.15.0.tgz#158adb88ed8004c6c49a396b50a6a5de3bca33ea"
   integrity sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==
 
-nopt@*, nopt@^5.0.0:
+nopt@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
   integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
@@ -11642,7 +11637,7 @@ normalize-url@^3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-npm-audit-report@*:
+npm-audit-report@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/npm-audit-report/-/npm-audit-report-2.1.5.tgz#a5b8850abe2e8452fce976c8960dd432981737b5"
   integrity sha512-YB8qOoEmBhUH1UJgh1xFAv7Jg1d+xoNhsDYiFQlEFThEBui0W1vIz2ZK6FVg4WZjwEdl7uBQlm1jy3MUfyHeEw==
@@ -11656,7 +11651,7 @@ npm-bundled@^1.1.1:
   dependencies:
     npm-normalize-package-bin "^1.0.1"
 
-npm-install-checks@*, npm-install-checks@^4.0.0:
+npm-install-checks@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/npm-install-checks/-/npm-install-checks-4.0.0.tgz#a37facc763a2fde0497ef2c6d0ac7c3fbe00d7b4"
   integrity sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==
@@ -11668,7 +11663,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
   resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
   integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
-npm-package-arg@*, npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-package-arg@^8.1.1, npm-package-arg@^8.1.2, npm-package-arg@^8.1.5:
+npm-package-arg@^8.0.0, npm-package-arg@^8.0.1, npm-package-arg@^8.1.0, npm-package-arg@^8.1.1, npm-package-arg@^8.1.2, npm-package-arg@^8.1.5:
   version "8.1.5"
   resolved "https://registry.yarnpkg.com/npm-package-arg/-/npm-package-arg-8.1.5.tgz#3369b2d5fe8fdc674baa7f1786514ddc15466e44"
   integrity sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==
@@ -11697,7 +11692,7 @@ npm-packlist@^3.0.0:
     npm-bundled "^1.1.1"
     npm-normalize-package-bin "^1.0.1"
 
-npm-pick-manifest@*, npm-pick-manifest@^6.0.0, npm-pick-manifest@^6.1.0, npm-pick-manifest@^6.1.1:
+npm-pick-manifest@^6.0.0, npm-pick-manifest@^6.1.0, npm-pick-manifest@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz#7b5484ca2c908565f43b7f27644f36bb816f5148"
   integrity sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==
@@ -11707,24 +11702,12 @@ npm-pick-manifest@*, npm-pick-manifest@^6.0.0, npm-pick-manifest@^6.1.0, npm-pic
     npm-package-arg "^8.1.2"
     semver "^7.3.4"
 
-npm-profile@*:
+npm-profile@^5.0.3:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-5.0.4.tgz#73e5bd1d808edc2c382d7139049cc367ac43161b"
   integrity sha512-OKtU7yoAEBOnc8zJ+/uo5E4ugPp09sopo+6y1njPp+W99P8DvQon3BJYmpvyK2Bf1+3YV5LN1bvgXRoZ1LUJBA==
   dependencies:
     npm-registry-fetch "^11.0.0"
-
-npm-registry-fetch@*:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-12.0.0.tgz#53d8c94f7c37293707b23728864710b76d3a3ca5"
-  integrity sha512-nd1I90UHoETjgWpo3GbcoM1l2S4JCUpzDcahU4x/GVCiDQ6yRiw2KyDoPVD8+MqODbPtWwHHGiyc4O5sgdEqPQ==
-  dependencies:
-    make-fetch-happen "^9.0.1"
-    minipass "^3.1.3"
-    minipass-fetch "^1.3.0"
-    minipass-json-stream "^1.0.1"
-    minizlib "^2.0.0"
-    npm-package-arg "^8.0.0"
 
 npm-registry-fetch@^11.0.0:
   version "11.0.0"
@@ -11752,7 +11735,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npm-user-validate@*:
+npm-user-validate@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/npm-user-validate/-/npm-user-validate-1.0.1.tgz#31428fc5475fe8416023f178c0ab47935ad8c561"
   integrity sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw==
@@ -11834,16 +11817,6 @@ npm@^8.1.1:
     which "^2.0.2"
     write-file-atomic "^3.0.3"
 
-npmlog@*, npmlog@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.0.tgz#ba9ef39413c3d936ea91553db7be49c34ad0520c"
-  integrity sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==
-  dependencies:
-    are-we-there-yet "^2.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^4.0.0"
-    set-blocking "^2.0.0"
-
 npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -11853,6 +11826,16 @@ npmlog@^4.1.2:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+npmlog@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-6.0.0.tgz#ba9ef39413c3d936ea91553db7be49c34ad0520c"
+  integrity sha512-03ppFRGlsyUaQFbGC2C8QWJN/C/K7PsfyD9aQdhVKAQIH4sQBc8WASqFBP7O+Ut4d2oo5LoeoboB3cGdBZSp6Q==
+  dependencies:
+    are-we-there-yet "^2.0.0"
+    console-control-strings "^1.1.0"
+    gauge "^4.0.0"
+    set-blocking "^2.0.0"
 
 nth-check@^1.0.2:
   version "1.0.2"
@@ -12056,7 +12039,7 @@ open@^7.0.2:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
-opener@*:
+opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
@@ -12222,31 +12205,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pacote@*, pacote@^12.0.0, pacote@^12.0.2:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-12.0.2.tgz#14ae30a81fe62ec4fc18c071150e6763e932527c"
-  integrity sha512-Ar3mhjcxhMzk+OVZ8pbnXdb0l8+pimvlsqBGRNkble2NVgyqOGE3yrCGi/lAYq7E7NRDMz89R1Wx5HIMCGgeYg==
-  dependencies:
-    "@npmcli/git" "^2.1.0"
-    "@npmcli/installed-package-contents" "^1.0.6"
-    "@npmcli/promise-spawn" "^1.2.0"
-    "@npmcli/run-script" "^2.0.0"
-    cacache "^15.0.5"
-    chownr "^2.0.0"
-    fs-minipass "^2.1.0"
-    infer-owner "^1.0.4"
-    minipass "^3.1.3"
-    mkdirp "^1.0.3"
-    npm-package-arg "^8.0.1"
-    npm-packlist "^3.0.0"
-    npm-pick-manifest "^6.0.0"
-    npm-registry-fetch "^11.0.0"
-    promise-retry "^2.0.1"
-    read-package-json-fast "^2.0.1"
-    rimraf "^3.0.2"
-    ssri "^8.0.1"
-    tar "^6.1.0"
-
 pacote@^11.3.0:
   version "11.3.5"
   resolved "https://registry.yarnpkg.com/pacote/-/pacote-11.3.5.tgz#73cf1fc3772b533f575e39efa96c50be8c3dc9d2"
@@ -12264,6 +12222,31 @@ pacote@^11.3.0:
     mkdirp "^1.0.3"
     npm-package-arg "^8.0.1"
     npm-packlist "^2.1.4"
+    npm-pick-manifest "^6.0.0"
+    npm-registry-fetch "^11.0.0"
+    promise-retry "^2.0.1"
+    read-package-json-fast "^2.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.1"
+    tar "^6.1.0"
+
+pacote@^12.0.0, pacote@^12.0.2:
+  version "12.0.2"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-12.0.2.tgz#14ae30a81fe62ec4fc18c071150e6763e932527c"
+  integrity sha512-Ar3mhjcxhMzk+OVZ8pbnXdb0l8+pimvlsqBGRNkble2NVgyqOGE3yrCGi/lAYq7E7NRDMz89R1Wx5HIMCGgeYg==
+  dependencies:
+    "@npmcli/git" "^2.1.0"
+    "@npmcli/installed-package-contents" "^1.0.6"
+    "@npmcli/promise-spawn" "^1.2.0"
+    "@npmcli/run-script" "^2.0.0"
+    cacache "^15.0.5"
+    chownr "^2.0.0"
+    fs-minipass "^2.1.0"
+    infer-owner "^1.0.4"
+    minipass "^3.1.3"
+    mkdirp "^1.0.3"
+    npm-package-arg "^8.0.1"
+    npm-packlist "^3.0.0"
     npm-pick-manifest "^6.0.0"
     npm-registry-fetch "^11.0.0"
     promise-retry "^2.0.1"
@@ -12312,7 +12295,7 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
-parse-conflict-json@*, parse-conflict-json@^1.1.1:
+parse-conflict-json@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-conflict-json/-/parse-conflict-json-1.1.1.tgz#54ec175bde0f2d70abf6be79e0e042290b86701b"
   integrity sha512-4gySviBiW5TRl7XHvp1agcS7SOe0KZOjC//71dzZVWJrY9hCrgtvl5v3SyIxCZ4fZF47TxD9nfzmxcx76xmbUw==
@@ -13297,7 +13280,7 @@ pretty-format@^27.0.0, pretty-format@^27.3.1, pretty-format@^27.4.2:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-proc-log@*, proc-log@^1.0.0:
+proc-log@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-1.0.0.tgz#0d927307401f69ed79341e83a0b2c9a13395eb77"
   integrity sha512-aCk8AO51s+4JyuYGg3Q/a6gnrlDO09NpVWePtjp7xwphcoQ04x5WAfCyugcsbLooWcMJ87CLkD4+604IckEdhg==
@@ -13461,7 +13444,7 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qrcode-terminal@*:
+qrcode-terminal@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
@@ -13940,7 +13923,7 @@ read-cmd-shim@^2.0.0:
   resolved "https://registry.yarnpkg.com/read-cmd-shim/-/read-cmd-shim-2.0.0.tgz#4a50a71d6f0965364938e9038476f7eede3928d9"
   integrity sha512-HJpV9bQpkl6KwjxlJcBoqu9Ba0PQg8TqSNIOrulGt54a0uup0HtevreFHzYzkm0lpnleRdNBzXznKrgxglEHQw==
 
-read-package-json-fast@*, read-package-json-fast@^2.0.1, read-package-json-fast@^2.0.2:
+read-package-json-fast@^2.0.1, read-package-json-fast@^2.0.2, read-package-json-fast@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/read-package-json-fast/-/read-package-json-fast-2.0.3.tgz#323ca529630da82cb34b36cc0b996693c98c2b83"
   integrity sha512-W/BKtbL+dUjTuRL2vziuYhp76s5HZ9qQhd/dKfWIZveD0O40453QNyZhC0e63lqZrAQ4jiOapVoeJ7JrszenQQ==
@@ -13948,7 +13931,7 @@ read-package-json-fast@*, read-package-json-fast@^2.0.1, read-package-json-fast@
     json-parse-even-better-errors "^2.3.0"
     npm-normalize-package-bin "^1.0.1"
 
-read-package-json@*, read-package-json@^4.1.1:
+read-package-json@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-4.1.1.tgz#153be72fce801578c1c86b8ef2b21188df1b9eea"
   integrity sha512-P82sbZJ3ldDrWCOSKxJT0r/CXMWR0OR3KRh55SgKo3p91GSIEEC32v3lSHAvO/UcH3/IoL7uqhOFBduAnwdldw==
@@ -13977,7 +13960,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-read@*, read@1, read@^1.0.7, read@~1.0.1:
+read@1, read@^1.0.7, read@~1.0.1, read@~1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
@@ -14006,7 +13989,7 @@ readable-stream@^3.0.6, readable-stream@^3.6.0:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.1.0:
+readdir-scoped-modules@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
   integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
@@ -14345,17 +14328,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@*, rimraf@^3.0.0, rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.0, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -14550,13 +14533,6 @@ selfsigned@^1.10.8:
   dependencies:
     node-forge "^0.10.0"
 
-semver@*, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
-  version "7.3.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
-  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
@@ -14576,6 +14552,13 @@ semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.17.1:
   version "0.17.1"
@@ -15026,19 +15009,19 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@*, ssri@^8.0.0, ssri@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
-  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
-  dependencies:
-    minipass "^3.1.1"
-
 ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
   integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
+
+ssri@^8.0.0, ssri@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.1.tgz#638e4e439e2ffbd2cd289776d5ca457c4f51a2af"
+  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
+  dependencies:
+    minipass "^3.1.1"
 
 stable@^0.1.8:
   version "0.1.8"
@@ -15408,7 +15391,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@*, tar@^6.0.2, tar@^6.1.0, tar@^6.1.2:
+tar@^6.0.2, tar@^6.1.0, tar@^6.1.11, tar@^6.1.2:
   version "6.1.11"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
   integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
@@ -15514,7 +15497,7 @@ test-exclude@^6.0.0:
     glob "^7.1.4"
     minimatch "^3.0.4"
 
-text-table@*, text-table@0.2.0, text-table@^0.2.0:
+text-table@0.2.0, text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
@@ -15563,7 +15546,7 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-relative-date@*:
+tiny-relative-date@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/tiny-relative-date/-/tiny-relative-date-1.3.0.tgz#fa08aad501ed730f31cc043181d995c39a935e07"
   integrity sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A==
@@ -15654,7 +15637,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-treeverse@*, treeverse@^1.0.4:
+treeverse@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/treeverse/-/treeverse-1.0.4.tgz#a6b0ebf98a1bca6846ddc7ecbc900df08cb9cd5f"
   integrity sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==
@@ -16077,7 +16060,7 @@ validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-validate-npm-package-name@*, validate-npm-package-name@^3.0.0:
+validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz#5fa912d81eb7d0c74afc140de7317f0ca7df437e"
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
@@ -16365,17 +16348,17 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@*, which@^2.0.1, which@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
-  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
-  dependencies:
-    isexe "^2.0.0"
-
 which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^2.0.1, which@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
 
@@ -16581,16 +16564,6 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@*, write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
-  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
-  dependencies:
-    imurmurhash "^0.1.4"
-    is-typedarray "^1.0.0"
-    signal-exit "^3.0.2"
-    typedarray-to-buffer "^3.1.5"
-
 write-file-atomic@^2.3.0:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
@@ -16599,6 +16572,16 @@ write-file-atomic@^2.3.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
 
 ws@^1.1.0, ws@^1.1.5:
   version "1.1.5"

--- a/web/pwa/src/components/RecordPicker.tsx
+++ b/web/pwa/src/components/RecordPicker.tsx
@@ -110,7 +110,7 @@ export const RecordPickerContainer: FC<RecordPickerContainerProps> = props => {
             }
             for (const field of form?.fields) {
                 if (field.key) {
-                    result += r.values[field.id]
+                    result += r.values.find(v => v.fieldId === field.id)
                 }
             }
             return result

--- a/web/pwa/src/components/RecordPicker.tsx
+++ b/web/pwa/src/components/RecordPicker.tsx
@@ -110,7 +110,7 @@ export const RecordPickerContainer: FC<RecordPickerContainerProps> = props => {
             }
             for (const field of form?.fields) {
                 if (field.key) {
-                    result += r.values.find(v => v.fieldId === field.id)
+                    result += r.values.find((v: any) => v.fieldId === field.id)
                 }
             }
             return result

--- a/web/pwa/src/features/browser/FolderBrowser.tsx
+++ b/web/pwa/src/features/browser/FolderBrowser.tsx
@@ -36,8 +36,8 @@ export const FolderBrowser: FC<FolderBrowserProps> = props => {
         forms,
     } = props
 
-    const formEntries = forms.map(f => <FormRow form={f}/>)
-    const folderEntries = folders.map(f => <FolderRow folder={f}/>)
+    const formEntries = forms.map(f => <FormRow key={f.id} form={f}/>)
+    const folderEntries = folders.map(f => <FolderRow key={f.id} folder={f}/>)
 
     const isEmpty = forms.length === 0 && folders.length === 0
     const isEmptyDatabase = folderId === undefined && isEmpty

--- a/web/pwa/src/features/browser/FormBrowser.tsx
+++ b/web/pwa/src/features/browser/FormBrowser.tsx
@@ -60,7 +60,7 @@ function mapRecordCell(field: FieldDefinition, record: Record, getSubFormCount: 
         </td>
     }
 
-    const fieldValue = record.values.find(v => v.fieldId === field.id)
+    const fieldValue = record.values.find((v: any) => v.fieldId === field.id)
 
     if (field.fieldType.month) {
 

--- a/web/pwa/src/features/browser/FormBrowser.tsx
+++ b/web/pwa/src/features/browser/FormBrowser.tsx
@@ -60,10 +60,18 @@ function mapRecordCell(field: FieldDefinition, record: Record, getSubFormCount: 
         </td>
     }
 
+    const fieldValue = record.values.find(v => v.fieldId === field.id)
+
     if (field.fieldType.month) {
+
+        let date: Date | undefined
+        if (fieldValue) {
+            date = new Date(fieldValue.value)
+        }
+
         return <td key={field.id} className={"text-secondary"}
-               style={{overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", wordBreak: "break-all"}}>
-            {format(new Date(record.values[field.id]), "yyyy-MM")}
+                   style={{overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", wordBreak: "break-all"}}>
+            {date ? format(date, "yyyy-MM") : ""}
         </td>
     }
 
@@ -77,7 +85,7 @@ function mapRecordCell(field: FieldDefinition, record: Record, getSubFormCount: 
 
     return <td key={field.id} className={"text-secondary"}
                style={{overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", wordBreak: "break-all"}}>
-        {record.values[field.id]}
+        {fieldValue?.value}
     </td>
 }
 

--- a/web/pwa/src/features/browser/RecordBrowser.tsx
+++ b/web/pwa/src/features/browser/RecordBrowser.tsx
@@ -1,5 +1,5 @@
 import {FC, Fragment} from "react";
-import {useFormOrSubForm, useRecordFromPath, useOwnerRecord, useSubRecords} from "../../app/hooks";
+import {useFormOrSubForm, useOwnerRecord, useRecordFromPath, useSubRecords} from "../../app/hooks";
 import {FieldDefinition, Record} from "core-js-api-client";
 import {Link} from "react-router-dom";
 import format from "date-fns/format"
@@ -33,8 +33,12 @@ const RecordField: FC<RecordFieldProps> = props => {
 
 
 function mapRecordField(record: Record, field: FieldDefinition, subRecords: Record[] | undefined) {
-    const value = record.values[field.id]
-    return <RecordField field={field} value={value} subRecords={subRecords}/>
+    let value = ""
+    const fieldValue = record.values.find(v => v.fieldId === field.id)
+    if (fieldValue) {
+        value = fieldValue.value
+    }
+    return <RecordField field={field} value={`${value}`} subRecords={subRecords}/>
 }
 
 export const RecordBrowser: FC = props => {

--- a/web/pwa/src/features/former/former.slice.ts
+++ b/web/pwa/src/features/former/former.slice.ts
@@ -202,7 +202,7 @@ const mapFields = (state: FormerState, fields: FormField[]): FieldDefinition[] =
             id: "",
             description: field.description,
             name: field.name,
-            options: "",
+            options: [],
             required: field.required,
             code: field.code,
             key: field.key

--- a/web/pwa/src/features/former/former.slice.ts
+++ b/web/pwa/src/features/former/former.slice.ts
@@ -202,7 +202,7 @@ const mapFields = (state: FormerState, fields: FormField[]): FieldDefinition[] =
             id: "",
             description: field.description,
             name: field.name,
-            options: field.options,
+            options: "",
             required: field.required,
             code: field.code,
             key: field.key
@@ -346,25 +346,25 @@ export const formerSlice = createSlice({
             }
             fieldForm.field.description = action.payload.description
         },
-        setFieldOption(state, action: PayloadAction<{fieldId: string, i: number, value: string}>) {
+        setFieldOption(state, action: PayloadAction<{ fieldId: string, i: number, value: string }>) {
             const fieldForm = selectFieldForm(state, action.payload.fieldId)
             const {i, value} = action.payload
             if (!fieldForm || !fieldForm.field.options) return
 
             fieldForm.field.options[i] = value
         },
-        addOption(state, action: PayloadAction<{fieldId: string}>) {
+        addOption(state, action: PayloadAction<{ fieldId: string }>) {
             const fieldForm = selectFieldForm(state, action.payload.fieldId)
             if (!fieldForm) return
 
             fieldForm.field.options = [...fieldForm.field?.options ?? [], ""]
         },
-        removeOption(state, action: PayloadAction<{fieldId: string, i: number}>) {
+        removeOption(state, action: PayloadAction<{ fieldId: string, i: number }>) {
             const fieldForm = selectFieldForm(state, action.payload.fieldId)
             if (!fieldForm || !fieldForm.field.options) return
 
             const {i} = action.payload
-            fieldForm.field.options = fieldForm.field.options.slice(0 , i).concat(fieldForm.field.options.slice(i + 1))
+            fieldForm.field.options = fieldForm.field.options.slice(0, i).concat(fieldForm.field.options.slice(i + 1))
         },
         setFieldCode(state, action: PayloadAction<{ fieldId: string, code: string }>) {
             const fieldForm = selectFieldForm(state, action.payload.fieldId)

--- a/web/pwa/src/features/recorder/FieldEditor.tsx
+++ b/web/pwa/src/features/recorder/FieldEditor.tsx
@@ -76,7 +76,16 @@ export const MonthFieldEditor: FC<FieldEditorProps> = props => {
     const {field, value, setValue} = props
     const expectedLength = 7;
 
-    const [localValue, setLocalValue] = useState(value != null ? format(value as Date, "yyyy-MM") : "")
+    const [localValue, setLocalValue] = useState<string>(() => {
+        if (!value) {
+            return ""
+        }
+        try {
+            return format(value, "yyyy-MM")
+        } catch (e) {
+            return ""
+        }
+    })
 
     const isValidLength = () => localValue.length === expectedLength;
 
@@ -135,7 +144,7 @@ export const SingleSelectFieldEditor: FC<FieldEditorProps> = props => {
             id={field.id} value={value ? value : ""}
             onChange={event => setValue(event.target.value)}>
             <option disabled={field.required || field.key} value={""}/>
-            {field.options.map(o => <option value={o}>{o}</option>)}
+            {/** TODO field.options.map(o => <option value={o}>{o}</option>)**/}
         </select>
         {mapFieldDescription(field)}
     </div>

--- a/web/pwa/src/features/recorder/RecordEditor.tsx
+++ b/web/pwa/src/features/recorder/RecordEditor.tsx
@@ -2,27 +2,30 @@ import React, {FC, Fragment, useCallback, useEffect, useState} from "react";
 import {
     FormValue,
     postRecord,
-    recorderActions, resetForm,
+    recorderActions,
+    resetForm,
     selectCurrentForm,
     selectCurrentRecord,
-    selectCurrentRootForm, selectPostRecords, selectSubRecords
+    selectCurrentRootForm,
+    selectPostRecords,
+    selectSubRecords
 } from "./recorder.slice";
 import {useAppDispatch, useAppSelector} from "../../app/hooks";
-import {FieldDefinition} from "core-js-api-client";
+import {FieldDefinition, FieldValue} from "core-js-api-client";
 import {FieldEditor} from "./FieldEditor";
 import {fetchDatabases} from "../../reducers/database";
 import {fetchFolders} from "../../reducers/folder";
 import {fetchForms, selectRootForm} from "../../reducers/form";
-import {useParams, useLocation} from "react-router-dom"
+import {useLocation, useParams} from "react-router-dom"
 
 export type RecordEditorProps = {
     formName: string
     fields: FieldDefinition[]
-    values: { [key: string]: any }
+    values: FieldValue[]
     setValue: (key: string, value: any) => void
     selectSubRecord: (subRecordId: string) => void
     addSubRecord: (ownerFieldId: string) => void
-    subRecords: {[key: string]: FormValue[]}
+    subRecords: { [key: string]: FormValue[] }
     saveRecord: () => void
 }
 
@@ -40,7 +43,8 @@ export const RecordEditor: FC<RecordEditorProps> = props => {
                     <div className={"card bg-dark text-light border-secondary"}>
                         <div className={"card-body"}>
                             {props.fields.map(field => {
-                                const value = props.values[field.id]
+                                const fieldValue = props.values.find(v => v.fieldId === field.id)
+                                const value = fieldValue?.value ? fieldValue.value : ""
                                 const setValue = (value: any) => {
                                     props.setValue(field.id, value)
                                 }
@@ -93,7 +97,7 @@ export const RecordEditorContainer: FC<{}> = props => {
     const currentForm = useAppSelector(selectCurrentForm)
     const currentRecord = useAppSelector(selectCurrentRecord)
     const subRecords = useAppSelector(state => {
-        if (currentRecord){
+        if (currentRecord) {
             return selectSubRecords(state, currentRecord.recordId)
         }
         return {}


### PR DESCRIPTION
Modifying the record.Values to be a []FieldValue instead of a map[string]interface{}. Much easier to deal with..
Also, all values passed to the API for field values are string or null
This also introduces a `formwriter` and `formreader` to read/write records
```
POST /records
{ 
  "formId":"...",
  "databaseId":"...",
  "values": [
    {"fieldId":"field-1","value":"123"}
  ]
}
```