### PR TITLE
COR-414 fix authnz-bouncer path prefix

### DIFF
--- a/pkg/server/auth/server.go
+++ b/pkg/server/auth/server.go
@@ -29,7 +29,7 @@ func NewServer(options Options) (*Server, error) {
 	}
 	authenticator := authenticators.NewHydraAuthenticator(options.HydraPublic)
 	authorizer := authorizers.NewHydraAuthorizer(options.HydraAdmin)
-	genericServer.NonGoRestfulMux.PathPrefix("/apis/authorization.nrc.no/v1/").Handler(handlers.HandleAuth(authenticator, authorizer))
+	genericServer.NonGoRestfulMux.PathPrefix("/").Handler(handlers.HandleAuth(authenticator, authorizer))
 	s := &Server{
 		options: options,
 		Server:  genericServer,


### PR DESCRIPTION
The `authnz-bouncer` is ran as a `ext_authz` plugin on envoy. It's a catch-all requests, so we need to listen to all requests.
The current path prefix was only listening to /apis/authorization.nrc.no/v1...