### PR TITLE
COR-408 do not run devinit on startup

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 )
 
@@ -9,9 +8,6 @@ import (
 var devCmd = &cobra.Command{
 	Use:   "dev",
 	Short: "developer tools",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("admin called")
-	},
 }
 
 func init() {


### PR DESCRIPTION
The previous logic was prompting for a `pet-name` on startup, even when running `core serve all`, etc. That broke running the server on the cloud, since it does not make sense to provide a pet name on kubernetes. It's only for local development