### PR TITLE
COR-424 fix docker build

### DIFF
--- a/build/package/core.Dockerfile
+++ b/build/package/core.Dockerfile
@@ -14,13 +14,14 @@ RUN go mod download
 ADD . .
 
 RUN go mod verify
+
 RUN CGO_ENABLED=1 \
     GOOS=linux \
     GOARCH=amd64 \
-    go build -a -ldflags '-linkmode external -extldflags "-static"' -o main .
+    go build -o main .
 
 # Build a small image
-FROM scratch
+FROM golang:1.16
 
 COPY --from=builder /go/src/github.com/nrc-no/core/main /core
 

--- a/configs/authnz-frontend/replace-env-vars.sh
+++ b/configs/authnz-frontend/replace-env-vars.sh
@@ -2,7 +2,7 @@
 set -e
 
 find /usr/share/nginx/html/ \
-  -type f \( -iname \*.js -o -iname \*.html -o -iname \*.json -o -iname \*.map \) \
+  -type f \( -iname \*.js -o -iname \*.html -o -iname \*.json -o -iname \*.map -o -iname \*.css \) \
   -exec sed -i "s~%{PUBLIC_URL}%~${PUBLIC_URL}~g" {} + \
   -exec sed -i "s~%{OIDC_ISSUER}%~${OIDC_ISSUER}~g" {} + \
   -exec sed -i "s~%{OAUTH_SCOPE}%~${OAUTH_SCOPE}~g" {} + \

--- a/configs/core-frontend/replace-env-vars.sh
+++ b/configs/core-frontend/replace-env-vars.sh
@@ -2,7 +2,7 @@
 set -e
 
 find /usr/share/nginx/html/ \
-  -type f \( -iname \*.js -o -iname \*.html -o -iname \*.json -o -iname \*.map \) \
+  -type f \( -iname \*.js -o -iname \*.html -o -iname \*.json -o -iname \*.map -o -iname \*.css \) \
   -exec sed -i "s~%{PUBLIC_URL}%~${PUBLIC_URL}~g" {} + \
   -exec sed -i "s~%{OIDC_ISSUER}%~${OIDC_ISSUER}~g" {} + \
   -exec sed -i "s~%{OAUTH_SCOPE}%~${OAUTH_SCOPE}~g" {} + \


### PR DESCRIPTION
Didn't find a way to use scratch as a base image yet. Seems that linking sqlite causes quite a lot of problems on that front. Reverting to golang base image for now
Also, use env substitution for css files