### PR TITLE
COR-426 allow string slice in record values

### DIFF
--- a/pkg/api/types/record.go
+++ b/pkg/api/types/record.go
@@ -1,5 +1,11 @@
 package types
 
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
 // RecordRef represents a key that allows referencing a single Record.
 type RecordRef struct {
 	// ID is the Record.ID
@@ -48,9 +54,92 @@ type Record struct {
 
 type Records []Record
 
+type StringOrArrayValue uint8
+
+const (
+	StringValue StringOrArrayValue = iota + 1
+	ArrayValue
+	NullValue
+)
+
+type StringOrArray struct {
+	Kind        StringOrArrayValue
+	StringValue string
+	ArrayValue  []string
+}
+
+func NewStringValue(value string) StringOrArray {
+	return StringOrArray{
+		Kind:        StringValue,
+		StringValue: value,
+	}
+}
+
+func NewArrayValue(value []string) StringOrArray {
+	return StringOrArray{
+		Kind:       ArrayValue,
+		ArrayValue: value,
+	}
+}
+
+func NewNullValue() StringOrArray {
+	return StringOrArray{
+		Kind: NullValue,
+	}
+}
+
+func (s StringOrArray) MarshalJSON() ([]byte, error) {
+	switch s.Kind {
+	case NullValue:
+		return json.Marshal(nil)
+	case ArrayValue:
+		return json.Marshal(append(s.ArrayValue))
+	case StringValue:
+		return json.Marshal(s.StringValue)
+	default:
+		return nil, fmt.Errorf("unknown value kind")
+	}
+}
+
+func (s *StringOrArray) UnmarshalJSON(b []byte) error {
+	jsonStr := string(b)
+	if jsonStr == "null" {
+		s.Kind = NullValue
+		return nil
+	}
+
+	if strings.HasPrefix(jsonStr, "[") {
+		s.Kind = ArrayValue
+		return json.Unmarshal(b, &s.ArrayValue)
+	}
+
+	s.Kind = StringValue
+	return json.Unmarshal(b, &s.StringValue)
+}
+
 type FieldValue struct {
-	FieldID string  `json:"fieldId"`
-	Value   *string `json:"value"`
+	FieldID string        `json:"fieldId"`
+	Value   StringOrArray `json:"value"`
+}
+
+func NewFieldStringValue(fieldID string, value string) FieldValue {
+	return FieldValue{
+		FieldID: fieldID,
+		Value:   NewStringValue(value),
+	}
+}
+
+func NewFieldArrayValue(fieldID string, value []string) FieldValue {
+	return FieldValue{
+		FieldID: fieldID,
+		Value:   NewArrayValue(value),
+	}
+}
+func NewFieldNullValue(fieldID string) FieldValue {
+	return FieldValue{
+		FieldID: fieldID,
+		Value:   NewNullValue(),
+	}
 }
 
 type FieldValues []FieldValue
@@ -64,7 +153,7 @@ func (f FieldValues) Find(fieldID string) (FieldValue, bool) {
 	return FieldValue{}, false
 }
 
-func (f FieldValues) SetValue(fieldID string, value *string) FieldValues {
+func (f FieldValues) SetValue(fieldID string, value StringOrArray) FieldValues {
 	values := f
 	for i, v := range values {
 		if v.FieldID == fieldID {
@@ -76,7 +165,7 @@ func (f FieldValues) SetValue(fieldID string, value *string) FieldValues {
 	return values
 }
 
-func (f FieldValues) SetValueForFieldName(formDefinition *FormDefinition, fieldName string, value *string) (FieldValues, error) {
+func (f FieldValues) SetValueForFieldName(formDefinition *FormDefinition, fieldName string, value StringOrArray) (FieldValues, error) {
 	values := f
 	field, err := formDefinition.Fields.GetFieldByName(fieldName)
 	if err != nil {

--- a/pkg/api/types/record_test.go
+++ b/pkg/api/types/record_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestStringOrArrayMarshaling tests that we can successfully Marshal and Unmarshal
+// a StringOrArray to/from a string or an array of string, depending on the underlying value.
+func TestStringOrArrayMarshaling(t *testing.T) {
+
+	tests := []struct {
+		name string
+		json string
+		val  StringOrArray
+	}{
+		{
+			name: "array",
+			json: `["val1","val2"]`,
+			val: StringOrArray{
+				Kind:       ArrayValue,
+				ArrayValue: []string{"val1", "val2"},
+			},
+		}, {
+			name: "string",
+			json: `"val1"`,
+			val: StringOrArray{
+				Kind:        StringValue,
+				StringValue: "val1",
+			},
+		}, {
+			name: "null string",
+			json: `null`,
+			val: StringOrArray{
+				Kind: NullValue,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			jsonBytes, err := json.Marshal(test.val)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.json, string(jsonBytes))
+			var val StringOrArray
+			if err := json.Unmarshal([]byte(test.json), &val); !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.val, val)
+		})
+	}
+
+}

--- a/pkg/api/types/validation/record.go
+++ b/pkg/api/types/validation/record.go
@@ -157,7 +157,7 @@ func ValidateRecordValues(path *validation.Path, recordValues types.FieldValues,
 	return result
 }
 
-func ValidateRecordValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 
 	var result validation.ErrorList
 	fieldKind, _ := field.FieldType.GetFieldKind()
@@ -183,7 +183,7 @@ func ValidateRecordValue(path *validation.Path, value *string, field *types.Fiel
 	return result
 }
 
-func ValidateRecordStringValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordStringValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	_, result, done := getStringValue(path, value, field, validation.ErrorList{})
 	if done {
 		return result
@@ -191,7 +191,7 @@ func ValidateRecordStringValue(path *validation.Path, value *string, field *type
 	return result
 }
 
-func ValidateRecordDateValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordDateValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	stringValue, result, done := getStringValue(path, value, field, validation.ErrorList{})
 	if done {
 		return result
@@ -204,7 +204,7 @@ func ValidateRecordDateValue(path *validation.Path, value *string, field *types.
 	return result
 }
 
-func ValidateRecordMonthValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordMonthValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	stringValue, result, done := getStringValue(path, value, field, validation.ErrorList{})
 	if done {
 		return result
@@ -217,7 +217,7 @@ func ValidateRecordMonthValue(path *validation.Path, value *string, field *types
 	return result
 }
 
-func ValidateRecordWeekValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordWeekValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	stringValue, result, done := getStringValue(path, value, field, validation.ErrorList{})
 	if done {
 		return result
@@ -232,20 +232,18 @@ func ValidateRecordWeekValue(path *validation.Path, value *string, field *types.
 	return result
 }
 
-func ValidateRecordQuantityValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordQuantityValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	var result validation.ErrorList
 	valuePath := path.Child("value")
 
-	if value == nil {
+	if value.Kind == types.NullValue {
 		if field.Required {
 			result = append(result, validation.Required(valuePath, errFieldValueRequired))
 		}
 		return result
 	}
 
-	stringValue := *value
-
-	_, err := strconv.Atoi(stringValue)
+	_, err := strconv.Atoi(value.StringValue)
 	if err != nil {
 		return append(result, validation.Invalid(valuePath, value, errRecordInvalidQuantity))
 	}
@@ -254,7 +252,7 @@ func ValidateRecordQuantityValue(path *validation.Path, value *string, field *ty
 	return result
 }
 
-func ValidateRecordReferenceValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordReferenceValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	stringValue, result, done := getStringValue(path, value, field, validation.ErrorList{})
 	if done {
 		return result
@@ -266,7 +264,7 @@ func ValidateRecordReferenceValue(path *validation.Path, value *string, field *t
 	return result
 }
 
-func ValidateRecordSingleSelectValue(path *validation.Path, value *string, field *types.FieldDefinition) validation.ErrorList {
+func ValidateRecordSingleSelectValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition) validation.ErrorList {
 	stringValue, result, done := getStringValue(path, value, field, validation.ErrorList{})
 	if done {
 		return result
@@ -285,21 +283,19 @@ func ValidateRecordSingleSelectValue(path *validation.Path, value *string, field
 	return result
 }
 
-func getStringValue(path *validation.Path, value *string, field *types.FieldDefinition, result validation.ErrorList) (string, validation.ErrorList, bool) {
+func getStringValue(path *validation.Path, value types.StringOrArray, field *types.FieldDefinition, result validation.ErrorList) (string, validation.ErrorList, bool) {
 	valuePath := path.Child("value")
-	if value == nil {
+	if value.Kind == types.NullValue {
 		if field.Required {
 			result = append(result, validation.Required(valuePath, errFieldValueRequired))
 		}
 		return "", result, true
 	}
 
-	stringValue := *value
-
-	if field.Required && strings.TrimSpace(stringValue) == "" {
+	if field.Required && strings.TrimSpace(value.StringValue) == "" {
 		result = append(result, validation.Required(valuePath, errFieldValueRequired))
 		return "", result, true
 	}
 
-	return stringValue, result, false
+	return value.StringValue, result, false
 }

--- a/pkg/api/types/validation/record_test.go
+++ b/pkg/api/types/validation/record_test.go
@@ -131,14 +131,14 @@ func TestValidateRecord(t *testing.T) {
 		}, {
 			name:          "missing field type",
 			form:          aTextForm(tu.FormField(tu.AField(tu.FieldID("someField")))),
-			recordOptions: tu.RecordValue("bla", pointers.String("snip")),
+			recordOptions: tu.RecordValue("bla", types.NewStringValue("snip")),
 			expect: validation.ErrorList{
 				validation.InternalError(valuePath, errors.New("failed to get field kind")),
 			},
 		}, {
 			name:          "extraneous field",
 			form:          aTextForm(),
-			recordOptions: tu.RecordValue("bla", pointers.String("snip")),
+			recordOptions: tu.RecordValue("bla", types.NewStringValue("snip")),
 			expect: validation.ErrorList{
 				validation.NotSupported(firstFieldPath, "bla", []string{fieldId}),
 			},
@@ -162,7 +162,7 @@ func TestValidateRecord(t *testing.T) {
 					),
 				),
 			),
-			recordOptions: tu.RecordValue("requiredField", pointers.String("")),
+			recordOptions: tu.RecordValue("requiredField", types.NewStringValue("")),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -177,7 +177,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("textField"), tu.FieldTypeText(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("textField", nil),
+			recordOptions: tu.RecordValue("textField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -186,14 +186,14 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("textField"), tu.FieldTypeText())),
 			),
-			recordOptions: tu.RecordValue("textField", nil),
+			recordOptions: tu.RecordValue("textField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "required multiline text field with nil value",
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("textField"), tu.FieldTypeMultilineText(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("textField", nil),
+			recordOptions: tu.RecordValue("textField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -202,7 +202,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("textField"), tu.FieldTypeMultilineText())),
 			),
-			recordOptions: tu.RecordValue("textField", nil),
+			recordOptions: tu.RecordValue("textField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "date field",
@@ -215,16 +215,16 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("dateField"), tu.FieldTypeDate())),
 			),
-			recordOptions: tu.RecordValue("dateField", pointers.String("someValue")),
+			recordOptions: tu.RecordValue("dateField", types.NewStringValue("someValue")),
 			expect: validation.ErrorList{
-				validation.Invalid(firstFieldValuePath, pointers.String("someValue"), errRecordInvalidDate),
+				validation.Invalid(firstFieldValuePath, types.NewStringValue("someValue"), errRecordInvalidDate),
 			},
 		}, {
 			name: "required empty date field",
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("dateField"), tu.FieldTypeDate(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("dateField", pointers.String("")),
+			recordOptions: tu.RecordValue("dateField", types.NewStringValue("")),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -233,7 +233,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("dateField"), tu.FieldTypeDate(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("dateField", nil),
+			recordOptions: tu.RecordValue("dateField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -242,7 +242,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("dateField"), tu.FieldTypeDate())),
 			),
-			recordOptions: tu.RecordValue("dateField", nil),
+			recordOptions: tu.RecordValue("dateField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "month field",
@@ -255,16 +255,16 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("monthField"), tu.FieldTypeMonth())),
 			),
-			recordOptions: tu.RecordValue("monthField", pointers.String("someValue")),
+			recordOptions: tu.RecordValue("monthField", types.NewStringValue("someValue")),
 			expect: validation.ErrorList{
-				validation.Invalid(firstFieldValuePath, pointers.String("someValue"), errRecordInvalidMonth),
+				validation.Invalid(firstFieldValuePath, types.NewStringValue("someValue"), errRecordInvalidMonth),
 			},
 		}, {
 			name: "required empty month field",
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("monthField"), tu.FieldTypeMonth(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("monthField", pointers.String("")),
+			recordOptions: tu.RecordValue("monthField", types.NewStringValue("")),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -273,7 +273,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("monthField"), tu.FieldTypeMonth(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("monthField", nil),
+			recordOptions: tu.RecordValue("monthField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -282,7 +282,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("monthField"), tu.FieldTypeMonth())),
 			),
-			recordOptions: tu.RecordValue("monthField", nil),
+			recordOptions: tu.RecordValue("monthField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "week field",
@@ -295,16 +295,16 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("weekField"), tu.FieldTypeWeek())),
 			),
-			recordOptions: tu.RecordValue("weekField", pointers.String("someValue")),
+			recordOptions: tu.RecordValue("weekField", types.NewStringValue("someValue")),
 			expect: validation.ErrorList{
-				validation.Invalid(firstFieldValuePath, pointers.String("someValue"), errRecordInvalidWeek),
+				validation.Invalid(firstFieldValuePath, types.NewStringValue("someValue"), errRecordInvalidWeek),
 			},
 		}, {
 			name: "required empty week field",
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("weekField"), tu.FieldTypeWeek(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("weekField", pointers.String("")),
+			recordOptions: tu.RecordValue("weekField", types.NewStringValue("")),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -313,7 +313,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("weekField"), tu.FieldTypeWeek(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("weekField", nil),
+			recordOptions: tu.RecordValue("weekField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -322,7 +322,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("weekField"), tu.FieldTypeWeek())),
 			),
-			recordOptions: tu.RecordValue("weekField", nil),
+			recordOptions: tu.RecordValue("weekField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "quantity field",
@@ -335,16 +335,16 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("quantityField"), tu.FieldTypeQuantity())),
 			),
-			recordOptions: tu.RecordValue("quantityField", pointers.String("someValue")),
+			recordOptions: tu.RecordValue("quantityField", types.NewStringValue("someValue")),
 			expect: validation.ErrorList{
-				validation.Invalid(firstFieldValuePath, pointers.String("someValue"), errRecordInvalidQuantity),
+				validation.Invalid(firstFieldValuePath, types.NewStringValue("someValue"), errRecordInvalidQuantity),
 			},
 		}, {
 			name: "required quantity field with nil value",
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("quantityField"), tu.FieldTypeQuantity(), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("quantityField", nil),
+			recordOptions: tu.RecordValue("quantityField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -353,7 +353,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("quantityField"), tu.FieldTypeQuantity())),
 			),
-			recordOptions: tu.RecordValue("quantityField", nil),
+			recordOptions: tu.RecordValue("quantityField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "reference field",
@@ -366,16 +366,16 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("referenceField"), tu.FieldTypeReference(aFormRef))),
 			),
-			recordOptions: tu.RecordValue("referenceField", pointers.String("someValue")),
+			recordOptions: tu.RecordValue("referenceField", types.NewStringValue("someValue")),
 			expect: validation.ErrorList{
-				validation.Invalid(firstFieldValuePath, pointers.String("someValue"), errRecordInvalidReferenceUid),
+				validation.Invalid(firstFieldValuePath, types.NewStringValue("someValue"), errRecordInvalidReferenceUid),
 			},
 		}, {
 			name: "required reference field with nil value",
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("referenceField"), tu.FieldTypeReference(aFormRef), tu.FieldRequired(true))),
 			),
-			recordOptions: tu.RecordValue("referenceField", nil),
+			recordOptions: tu.RecordValue("referenceField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -384,7 +384,7 @@ func TestValidateRecord(t *testing.T) {
 			form: aTextForm(
 				tu.FormField(tu.AField(tu.FieldID("referenceField"), tu.FieldTypeReference(aFormRef))),
 			),
-			recordOptions: tu.RecordValue("referenceField", nil),
+			recordOptions: tu.RecordValue("referenceField", types.NewNullValue()),
 			expect:        nil,
 		}, {
 			name: "single select field",
@@ -407,7 +407,7 @@ func TestValidateRecord(t *testing.T) {
 					),
 				),
 			),
-			recordOptions: tu.RecordValue("singleSelectField", pointers.String("someRandomValue")),
+			recordOptions: tu.RecordValue("singleSelectField", types.NewStringValue("someRandomValue")),
 			expect: validation.ErrorList{
 				validation.NotSupported(firstFieldValuePath, "someRandomValue", []string{
 					"option1",
@@ -425,7 +425,7 @@ func TestValidateRecord(t *testing.T) {
 					),
 				),
 			),
-			recordOptions: tu.RecordValue("singleSelectField", nil),
+			recordOptions: tu.RecordValue("singleSelectField", types.NewNullValue()),
 			expect: validation.ErrorList{
 				validation.Required(firstFieldValuePath, errFieldValueRequired),
 			},
@@ -439,7 +439,7 @@ func TestValidateRecord(t *testing.T) {
 					),
 				),
 			),
-			recordOptions: tu.RecordValue("singleSelectField", nil),
+			recordOptions: tu.RecordValue("singleSelectField", types.NewNullValue()),
 		},
 	}
 

--- a/pkg/server/public/tests/record_test.go
+++ b/pkg/server/public/tests/record_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"github.com/nrc-no/core/pkg/api/types"
 	tu "github.com/nrc-no/core/pkg/testutils"
-	"github.com/nrc-no/core/pkg/utils/pointers"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,15 +47,15 @@ func (s *Suite) TestRecordCreateReadList() {
 	}
 
 	var values types.FieldValues
-	values, _ = values.SetValueForFieldName(&form, textFieldName, pointers.String("text value"))
-	values, _ = values.SetValueForFieldName(&form, monthFieldName, pointers.String("2010-01"))
-	values, _ = values.SetValueForFieldName(&form, dateFieldName, pointers.String("2010-12-31"))
-	values, _ = values.SetValueForFieldName(&form, weekFieldName, pointers.String("2020-W10"))
-	values, _ = values.SetValueForFieldName(&form, multilineTextFieldName, pointers.String("text\nvalue"))
-	values, _ = values.SetValueForFieldName(&form, quantityFieldName, pointers.String("10"))
+	values, _ = values.SetValueForFieldName(&form, textFieldName, types.NewStringValue("text value"))
+	values, _ = values.SetValueForFieldName(&form, monthFieldName, types.NewStringValue("2010-01"))
+	values, _ = values.SetValueForFieldName(&form, dateFieldName, types.NewStringValue("2010-12-31"))
+	values, _ = values.SetValueForFieldName(&form, weekFieldName, types.NewStringValue("2020-W10"))
+	values, _ = values.SetValueForFieldName(&form, multilineTextFieldName, types.NewStringValue("text\nvalue"))
+	values, _ = values.SetValueForFieldName(&form, quantityFieldName, types.NewStringValue("10"))
 
 	singleSelectField, _ := form.Fields.GetFieldByName(singleSelectFieldName)
-	values, _ = values.SetValueForFieldName(&form, singleSelectFieldName, pointers.String(singleSelectField.FieldType.SingleSelect.Options[0].ID))
+	values, _ = values.SetValueForFieldName(&form, singleSelectFieldName, types.NewStringValue(singleSelectField.FieldType.SingleSelect.Options[0].ID))
 
 	var record types.Record
 	if err := s.cli.CreateRecord(ctx, &types.Record{

--- a/pkg/sqlmanager/formreader_test.go
+++ b/pkg/sqlmanager/formreader_test.go
@@ -39,6 +39,13 @@ func Test_readRecords(t *testing.T) {
 	}
 
 	recordWithValue := func(value *string, options ...testutils.RecordOption) types.Record {
+		var val types.StringOrArray
+		if value == nil {
+			val = types.NewNullValue()
+		} else {
+			val = types.NewStringValue(*value)
+		}
+		
 		r := &types.Record{
 			ID:         recordId,
 			DatabaseID: databaseId,
@@ -46,7 +53,7 @@ func Test_readRecords(t *testing.T) {
 			Values: []types.FieldValue{
 				{
 					FieldID: keyMyFieldID,
-					Value:   value,
+					Value:   val,
 				},
 			},
 		}

--- a/pkg/testutils/options.go
+++ b/pkg/testutils/options.go
@@ -63,7 +63,7 @@ func RecordValues(values types.FieldValues) RecordOption {
 	}
 }
 
-func RecordValue(fieldID string, value *string) RecordOption {
+func RecordValue(fieldID string, value types.StringOrArray) RecordOption {
 	return func(record *types.Record) *types.Record {
 		val := types.FieldValue{
 			FieldID: fieldID,
@@ -79,6 +79,7 @@ func RecordValue(fieldID string, value *string) RecordOption {
 		return record
 	}
 }
+
 func RecordOmitValue(fieldID string) RecordOption {
 	return func(record *types.Record) *types.Record {
 		res := types.FieldValues{}
@@ -411,45 +412,21 @@ func RecordForForm(form types.FormInterface) RecordOption {
 		}
 		for _, field := range form.GetFields() {
 			if field.FieldType.Date != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String("2020-01-01"),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, "2020-01-01"))
 			} else if field.FieldType.Month != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String("2020-01"),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, "2020-01"))
 			} else if field.FieldType.Week != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String("2020-W01"),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, "2020-W01"))
 			} else if field.FieldType.Text != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String("abc"),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, "abc"))
 			} else if field.FieldType.MultilineText != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String("abc\ndef"),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, "abc\ndef"))
 			} else if field.FieldType.Reference != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String(uuid.NewV4().String()),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, uuid.NewV4().String()))
 			} else if field.FieldType.Quantity != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String("10"),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, "10"))
 			} else if field.FieldType.SingleSelect != nil {
-				r.Values = append(r.Values, types.FieldValue{
-					FieldID: field.ID,
-					Value:   pointers.String(field.FieldType.SingleSelect.Options[0].ID),
-				})
+				r.Values = append(r.Values, types.NewFieldStringValue(field.ID, field.FieldType.SingleSelect.Options[0].ID))
 			}
 		}
 		return r


### PR DESCRIPTION
To allow multi-select field values through the api, we need to allow the user to `POST` either strings or string arrays
so that
```
POST /records

formId: form1
values:
- fieldId: field1
  value: value1
```
Could also allow
```
POST /records

formId: form1
values:
- fieldId: field1
  value: value1
- fieldId: field2
  value: [value2, value3]
```

Current approach introduces a struct `StringOrArray` that will be properly de-serialized based on the json input.
