### PR TITLE
Handle checks for null/not null single select cases

### DIFF
--- a/pkg/sqlmanager/build_single_select_field.go
+++ b/pkg/sqlmanager/build_single_select_field.go
@@ -29,7 +29,29 @@ func singleSelectFieldActions(formInterface types.FormInterface, fieldDefinition
 		availableOptions = append(availableOptions, pq.QuoteLiteral(option.ID))
 	}
 
-	checkConstraint := fmt.Sprintf("%s IN (%s)",
+	// Handling for nullable single select fields and NULL values.
+	//
+	// See https://www.postgresql.org/docs/9.4/ddl-constraints.html
+	//
+	// Here, the sql `CHECK ("field" in ('option1','options2'))` would still evaluate to true according to the docs.
+	// > It should be noted that a check constraint is satisfied if the check expression evaluates to true or the
+	// > null value. Since most expressions will evaluate to the null value if any operand is null, they will not
+	// > prevent null values in the constrained columns. To ensure that a column does not contain null values,
+	// > the not-null constraint described in the next section can be used.
+	//
+	// If the field is not required, the column definition would be:
+	// "fieldId" varchar(36) CHECK "fieldId" is null or "fieldId" in ('opt1','opt2')
+	//
+	// If the field is required, the column definition would be:
+	// "fieldId" varchar(36) not null check "fieldId" in ('opt1','opt2')
+	//
+	canBeNullStatement := ""
+	if !fieldDefinition.Required {
+		canBeNullStatement = fmt.Sprintf("%s is null or ", pq.QuoteIdentifier(sqlField.Name))
+	}
+
+	checkConstraint := fmt.Sprintf("%s%s in (%s)",
+		canBeNullStatement,
 		pq.QuoteIdentifier(sqlField.Name),
 		strings.Join(availableOptions, ","),
 	)

--- a/pkg/sqlmanager/schema_test.go
+++ b/pkg/sqlmanager/schema_test.go
@@ -329,7 +329,37 @@ create table "databaseId"."subFormField"(
 			}},
 			want: []schema.DDL{
 				{Query: createTableDDL},
-				{Query: `alter table "databaseId"."formId" add "singleSelectField" varchar(36) check ("singleSelectField" IN ('option1','option2'));`},
+				{Query: `alter table "databaseId"."formId" add "singleSelectField" varchar(36) check ("singleSelectField" is null or "singleSelectField" in ('option1','option2'));`},
+			},
+		},
+		{
+			name: "form with required single select field",
+			args: []*types.FormDefinition{{
+				ID:         formId,
+				DatabaseID: databaseId,
+				Fields: []*types.FieldDefinition{
+					{
+						ID:       "singleSelectField",
+						Required: true,
+						FieldType: types.FieldType{
+							SingleSelect: &types.FieldTypeSingleSelect{
+								Options: []*types.SelectOption{
+									{
+										ID:   "option1",
+										Name: "Option 1",
+									}, {
+										ID:   "option2",
+										Name: "Option 2",
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+			want: []schema.DDL{
+				{Query: createTableDDL},
+				{Query: `alter table "databaseId"."formId" add "singleSelectField" varchar(36) not null check ("singleSelectField" in ('option1','option2'));`},
 			},
 		},
 	}


### PR DESCRIPTION
Forgot the case where `singleSelect` fields might have a null value. It did work anyways, because postgres's handling of NULL values and checks. But simply making it explicit in the `CHECK` constraint that we can receive a null value.