### PR TITLE
Serve backend command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,10 @@ serve-storybook:
 serve:
 	@./scripts/serve.sh
 
+.PHONY: serve-backend
+serve-backend:
+	@./scripts/serve-backend.sh
+
 .PHONY: watch
 watch:
 	@./scripts/watch.sh

--- a/scripts/serve-backend.sh
+++ b/scripts/serve-backend.sh
@@ -33,7 +33,7 @@ trap cleanup SIGINT EXIT ERR HUP INT QUIT TERM
 
 echo "Starting tunnels..."
 make tunnels > /dev/null 2>&1 &
-TUNNELL_PID=$!
+TUNNEL_PID=$!
 echo "Tunnel running on PID ${TUNNEL_PID}"
 
 echo "Starting proxy..."

--- a/scripts/serve-backend.sh
+++ b/scripts/serve-backend.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+cd "${SCRIPT_DIR}/.."
+
+TUNNEL_PID=
+PROXY_PID=
+SERVE_PID=
+DOCKER_UP=0
+
+function cleanup {
+  echo "Cleaning up..."
+  if [ -n "${TUNNEL_PID}" ]; then
+    echo "Killing tunnel..."
+    kill "${TUNNEL_PID}"
+  fi
+  if [ -n "${PROXY_PID}" ]; then
+    echo "Killing proxy..."
+    kill "${PROXY_PID}"
+  fi
+  if [ -n "${SERVE_PID}" ]; then
+    echo "Killing backend..."
+    kill "${SERVE_PID}"
+  fi
+  if [ "${DOCKER_UP}" -eq 1 ]; then
+    echo "Stopping docker..."
+    make down
+  fi
+}
+
+trap cleanup SIGINT EXIT ERR HUP INT QUIT TERM
+
+echo "Starting tunnels..."
+make tunnels > /dev/null 2>&1 &
+TUNNELL_PID=$!
+echo "Tunnel running on PID ${TUNNEL_PID}"
+
+echo "Starting proxy..."
+make proxy-local > /dev/null 2>&1 &
+PROXY_PID=$!
+echo "Proxy running on PID ${PROXY_PID}"
+
+echo "Bringing up docker..."
+make up
+DOCKER_UP=1
+
+echo "Waiting 30s for docker images to come up..."
+sleep 30
+
+echo "Bootstrapping backend..."
+make bootstrap
+
+echo "Serving backend..."
+make serve &
+SERVE_PID=$!
+echo "Backend running on PID ${SERVE_PID}"

--- a/scripts/serve-backend.sh
+++ b/scripts/serve-backend.sh
@@ -29,7 +29,7 @@ function cleanup {
   fi
 }
 
-trap cleanup SIGINT EXIT ERR HUP INT QUIT TERM
+trap cleanup EXIT
 
 echo "Starting tunnels..."
 make tunnels > /dev/null 2>&1 &

--- a/scripts/serve-backend.sh
+++ b/scripts/serve-backend.sh
@@ -55,3 +55,5 @@ echo "Serving backend..."
 make serve &
 SERVE_PID=$!
 echo "Backend running on PID ${SERVE_PID}"
+
+wait


### PR DESCRIPTION
This pr adds a make command to run everything needed for the backend. It's intend to be used when developing the frontend.

On startup it:

* Start tunnels
* Start local proxy
* Start up docker containers
* Run bootstrap
* Start api server

On exit it:

* Kills all running processes
* Tears down docker containers

Some nice additional features for the future:

* Options to disable various bits (eg. don't run the server because you want to run it with a debugger)
* Option to configure the docker timeout (30s may be too long)