### PR TITLE
COR 445 Colombia Seeder  Data

### DIFF
--- a/cmd/seed_colombia.go
+++ b/cmd/seed_colombia.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/nrc-no/core/pkg/client"
+	"github.com/nrc-no/core/pkg/logging"
+	"github.com/nrc-no/core/pkg/rest"
+	"github.com/nrc-no/core/pkg/seeder"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+)
+
+var seedColombia = &cobra.Command{
+	Use:   "colombia",
+	Short: "Seed the database with default forms and fields for the Colombia context",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logging.SetLogLevel(zap.DebugLevel)
+
+		ctx := context.Background()
+		url, err := url.Parse(endpoint)
+		if err != nil {
+			return err
+		}
+
+		client := client.NewClientFromConfig(rest.Config{
+			Scheme: url.Scheme,
+			Host:   url.Host,
+		})
+
+		s, err := seeder.NewSeed(ctx, client)
+		if err != nil {
+			return err
+		}
+		return s.Seed(ctx, client, seeder.ColombiaContext)
+	},
+}
+
+func init() {
+  seedCmd.AddCommand(seedColombia)
+}

--- a/pkg/seeder/colombia_dropdown_options.go
+++ b/pkg/seeder/colombia_dropdown_options.go
@@ -1,0 +1,21 @@
+package seeder
+
+import "github.com/nrc-no/core/pkg/api/types"
+
+type Options = []*types.SelectOption
+var (
+  co_nationality1 = Options{}
+  co_nationality2 = Options{}
+  co_marital_status = Options{}
+  relationship_to_hh = Options{}
+  co_beneficiary_type = Options{}
+  co_ethnicity = Options{}
+  co_identification_type = Options{}
+  co_identification_source = Options{}
+  co_countries = Options{}
+  co_admin_2 = Options{}
+  co_settlement_type = Options{}
+  co_means_of_contact = Options{}
+  co_service_delivery_modalities = Options{}
+  co_intro_source = Options{}
+)

--- a/pkg/seeder/seed.go
+++ b/pkg/seeder/seed.go
@@ -14,6 +14,8 @@ type CountryContext = string
 const (
 	GlobalContext                       CountryContext = "Global"
 	GlobalDatabaseName                                 = "Global"
+	ColombiaContext                     CountryContext = "Colombia"
+	ColombiaDatabaseName                               = "Colombia"
 	GlobalBioDataFolderName                            = "Global Bio Information"
 	GlobalIndividualFormName                           = "Individual"
 	GlobalHouseholdFormName                            = "Household"
@@ -90,8 +92,8 @@ func (s *Seed) Seed(ctx context.Context, client client.Client, countryContext Co
 	switch countryContext {
 	case GlobalContext:
 		return s.seedGlobal(ctx, client)
-	case UgandaContext:
-		/* return s.seedUganda() */
+	case ColombiaContext:
+		return s.seedColombia(ctx, client)
 	default:
 		return fmt.Errorf("invalid country context")
 	}

--- a/pkg/seeder/seed_colombia.go
+++ b/pkg/seeder/seed_colombia.go
@@ -1,0 +1,229 @@
+package seeder
+
+import (
+	"context"
+
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/client"
+)
+
+func (s *Seed) seedColombia(ctx context.Context, client client.Client) error {
+	var err error
+
+	var co_db types.Database
+
+	err = client.CreateDatabase(ctx, &types.Database{Name: "Colombia"}, &co_db)
+
+	if err != nil {
+		return err
+	}
+
+	err = s.seedCoIntake(ctx, client, co_db.ID)
+
+	if err != nil {
+		return err
+	}
+
+	err = s.seedCoConsent(ctx, client, co_db.ID)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Seed) seedCoIntake(ctx context.Context, client client.Client, dbID string) error {
+	var (
+		err                    error
+		intake_folder          *types.Folder
+		intake_pii             *types.FormDefinition
+		intake_id_details      *types.FormDefinition
+		intake_nrc_details     *types.FormDefinition
+		intake_contact_info    *types.FormDefinition
+		intake_ind_cc_specific *types.FormDefinition
+		intake_hh_information  *types.FormDefinition
+	)
+
+	var forms = []*types.FormDefinition{
+		intake_pii,
+		intake_id_details,
+		intake_nrc_details,
+		intake_contact_info,
+		intake_ind_cc_specific,
+		intake_hh_information,
+	}
+
+	err = client.CreateFolder(ctx, &types.Folder{
+		Name:       "Intake",
+		DatabaseID: dbID,
+	}, intake_folder)
+
+	if err != nil {
+		return err
+	}
+
+	intake_pii = &types.FormDefinition{
+		Name:       "Individual PII",
+		DatabaseID: dbID,
+		FolderID:   intake_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			date("Date of birth", true),
+			dropdown("Nationality (1)", co_nationality1, false),
+			dropdown("Nationality (2)", co_nationality2, false),
+			dropdown("Marital status", co_marital_status, true),
+			dropdown("Relationship to HH representative", relationship_to_hh, true),
+			dropdown("Beneficiary type", co_beneficiary_type, true),
+			dropdown("Ethnicity", co_ethnicity, true),
+			yesNo("Do you have a job or entrepreneurship", true),
+			text("What sector? (commerce, production, service, agro)", false),
+			text("Entrepreneurship time", false),
+			text("Type of job (contract type)", false),
+			textarea("Types of income sources in the family", false),
+			text("Name and surname of the legal representative", false),
+			text("Additional information about the legal representative", false),
+			textarea("Reasons for the representation", false),
+			yesNo("Is the guardianship legal under national law?", false),
+			textarea("Add the legal evaluation (if the answer is positive)", false),
+			textarea("Offer assistance in identifying a recognized legal representative (if the answer is negative)", false),
+			yesNo("Can the person give their consent legally?", false),
+			quantity("Age of head of household (if another person, and if the household is not registered)", false),
+			quantity("Monthly household income / per capita", false),
+			yesNo("Is the head of household is pregnant or nursing?", false),
+			yesNo("Does the head of household have a chronic illness?", false),
+		},
+	}
+
+	intake_id_details = &types.FormDefinition{
+		Name:       "ID Details",
+		DatabaseID: dbID,
+		FolderID:   intake_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			dropdown("Type of identification", co_identification_type, true),
+			ifOtherPleaseSpecify,
+			text("Identification number", true),
+			text("Additional ID #1", false),
+			text("Additional ID #2", false),
+		},
+	}
+
+	intake_nrc_details = &types.FormDefinition{
+		Name:       "NRC Details",
+		DatabaseID: dbID,
+		FolderID:   intake_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			dropdown("Source of identification", co_identification_source, true),
+			text("Location name", true),
+			date("Registration date", false),
+			dropdown("Country", co_countries, true),
+			dropdown("District", co_admin_2, true),
+			text("Subcounty", false),
+			dropdown("Type of settlement", co_settlement_type, false),
+			text("Parish", false),
+			text("Village", false),
+			yesNo("Emergency attencion?", true),
+			yesNo("Sustainable solutions?", true),
+			yesNo("Hard to reach area?", true),
+			yesNo("COVID-19 emergency?", true),
+			text("How did you learn about NRC?", true),
+		},
+	}
+
+	intake_contact_info = &types.FormDefinition{
+		Name:       "Contact Information",
+		DatabaseID: dbID,
+		FolderID:   intake_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			textarea("Spoken languages", true),
+			text("Preferred language", true),
+			text("Email address", false),
+			textarea("Physical address", false),
+			text("Phone number (1)", false),
+			text("Phone number (2)", false),
+			text("Phone number (3)", false),
+			dropdown("Preferred means of contact", co_means_of_contact, true),
+			yesNo("Requires an interpreter?", true),
+			text("Interpreter name", false),
+		},
+	}
+
+	intake_ind_cc_specific = &types.FormDefinition{
+		Name:       "Individual CC Specific",
+		DatabaseID: dbID,
+		FolderID:   intake_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			text("Case number", true),
+			text("Caseworker/Paralegal's ID number", false),
+			dropdown("Modality of service delivery (taxonomy)", co_service_delivery_modalities, false),
+			text("Living situation", true),
+			textarea("Comment on living situation", false),
+			dropdown("How did you learn about our services?", co_intro_source, true),
+		},
+	}
+
+	intake_hh_information = &types.FormDefinition{
+		Name:       "Household Information",
+		DatabaseID: dbID,
+		FolderID:   intake_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			quantity("Number of 60+ years old males", true),
+			text("Household/OPM Number", false),
+			text("Scholarship level of head of household", false),
+			quantity("Total number of people who are part of the household", true),
+			quantity("# of household members who have a disability", false),
+			quantity("# of household members who are pregnant or nursing", false),
+			quantity("# of household members who have a chronic illness", false),
+		},
+	}
+
+	for _, form := range forms {
+		err = client.CreateForm(ctx, form, nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+func (s *Seed) seedCoConsent(ctx context.Context, client client.Client, dbID string) error {
+	var (
+		err                error
+		consent_folder     *types.Folder
+		consent_individual *types.FormDefinition
+	)
+
+	err = client.CreateFolder(ctx, &types.Folder{
+		Name:       "Consent",
+		DatabaseID: dbID,
+	}, consent_folder)
+
+	if err != nil {
+		return err
+	}
+
+	consent_individual = &types.FormDefinition{
+		Name:       "Individual Consent",
+		DatabaseID: dbID,
+		FolderID:   consent_folder.ID,
+		Fields: types.FieldDefinitions{
+			s.globalBeneficiaryRefField,
+			text("Upload the consent form signed by the beneficiary", true),
+			yesNo("Can NRC staff initiate contact with the beneficiary?", true),
+			yesNo("Format of the act of commitment to the program", true),
+			yesNo("Format of delivery for assets and inputs", true),
+			textarea("Other consent information", false),
+			yesNo("Can NRC share the beneficiary's data?", true),
+		},
+	}
+
+	err = client.CreateForm(ctx, consent_individual, nil)
+
+	return err
+}

--- a/pkg/seeder/seed_colombia.go
+++ b/pkg/seeder/seed_colombia.go
@@ -12,7 +12,7 @@ func (s *Seed) seedColombia(ctx context.Context, client client.Client) error {
 
 	var co_db types.Database
 
-	err = client.CreateDatabase(ctx, &types.Database{Name: "Colombia"}, &co_db)
+	err = client.CreateDatabase(ctx, &types.Database{Name: ColombiaDatabaseName}, &co_db)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
This branches off of the Skeleton branch.

Lots of data missing; not our fault. :shrug:

Touched files are `seed_colombia.go` `columbia_dropdown_options.go` and some minor references elsewhere

with the server running in the background, invoke the script with 
`go run . seed -e "https://localhost:9000" global`
then
`go run . seed -e "https://localhost:9000" colombia`

in that order.