### PR TITLE
COR-499 add form type

### DIFF
--- a/frontend/packages/core-api-client/src/lib/types/index.ts
+++ b/frontend/packages/core-api-client/src/lib/types/index.ts
@@ -56,7 +56,8 @@ export type FieldTypeMultiSelect = {
   options: SelectOption[];
 };
 
-export class FieldTypeWeek {}
+export class FieldTypeWeek {
+}
 
 export type FieldTypeReference = {
   databaseId: string;
@@ -77,12 +78,18 @@ export type FieldDefinition = {
   fieldType: FieldType;
 };
 
+export enum FormType {
+  DefaultFormType = "default",
+  RecipientFormType = "recipient"
+}
+
 export type FormDefinition = {
   id: string;
   code: string;
   databaseId: string;
   folderId: string;
   name: string;
+  type: FormType;
   fields: FieldDefinition[];
 };
 
@@ -217,4 +224,5 @@ export interface ClientDefinition
     RecordLister,
     RecordGetter,
     FolderLister,
-    FolderCreator {}
+    FolderCreator {
+}

--- a/pkg/api/types/defaults/form.go
+++ b/pkg/api/types/defaults/form.go
@@ -1,0 +1,14 @@
+package defaults
+
+import "github.com/nrc-no/core/pkg/api/types"
+
+// FormDefinitionDefaults sets the default values for a types.FormDefinition
+func FormDefinitionDefaults(definition types.FormDefinition) types.FormDefinition {
+
+	// sets the default FormDefinition.Type
+	if len(definition.Type) == 0 {
+		definition.Type = types.DefaultFormType
+	}
+
+	return definition
+}

--- a/pkg/api/types/form.go
+++ b/pkg/api/types/form.go
@@ -2,7 +2,18 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/nrc-no/core/pkg/utils/sets"
+)
+
+// FormType represents the type of Form
+type FormType string
+
+const (
+	// DefaultFormType represents a generic form definition
+	DefaultFormType FormType = "default"
+	// RecipientFormType represents a form definition for a beneficiary
+	RecipientFormType FormType = "recipient"
 )
 
 // FormDefinition represents the definition of a Form for data collection.
@@ -11,14 +22,18 @@ type FormDefinition struct {
 	ID string `json:"id" yaml:"id"`
 	// DatabaseID of the FormDefinition
 	DatabaseID string `json:"databaseId" yaml:"databaseId"`
+	// Fields that constitute the FormDefinition
+	Fields FieldDefinitions `json:"fields" yaml:"fields"`
 	// FolderID of the FormDefinition. If the FolderID is empty,
 	// this means that the FormDefinition exists at the root
 	// of the DatabaseID
 	FolderID string `json:"folderId,omitempty" yaml:"folderId,omitempty"`
+	// Type of FormDefinition
+	// TODO: Ideally the "Recipient" forms, or other types of forms would
+	// have own API instead of adding fields on the FormDefinition.
+	Type FormType `json:"formType,omitempty" yaml:"formType,omitempty"`
 	// Name of the FormDefinition
 	Name string `json:"name" yaml:"name"`
-	// Fields that constitute the FormDefinition
-	Fields FieldDefinitions `json:"fields" yaml:"fields"`
 }
 
 // GetDatabaseID implements FormInterface.GetDatabaseID

--- a/pkg/api/types/validation/form.go
+++ b/pkg/api/types/validation/form.go
@@ -2,13 +2,14 @@ package validation
 
 import (
 	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
 	"github.com/nrc-no/core/pkg/api/types"
 	"github.com/nrc-no/core/pkg/utils/sets"
 	"github.com/nrc-no/core/pkg/validation"
 	uuid "github.com/satori/go.uuid"
-	"reflect"
-	"regexp"
-	"strings"
 )
 
 const (
@@ -62,6 +63,7 @@ func ValidateForm(form *types.FormDefinition) validation.ErrorList {
 	result = append(result, ValidateFormName(form.Name, validation.NewPath("name"))...)
 	result = append(result, ValidateFormDatabaseID(form.DatabaseID, validation.NewPath("databaseId"))...)
 	result = append(result, ValidateFormFolderID(form.FolderID, validation.NewPath("folderId"))...)
+	result = append(result, ValidateFormType(form.Type, validation.NewPath("type"))...)
 	result = append(result, ValidateFormFields(form.Fields, validation.NewPath("fields"))...)
 	return result
 }
@@ -123,6 +125,21 @@ func ValidateFormFolderID(folderId string, path *validation.Path) validation.Err
 	if _, err := uuid.FromString(folderId); err != nil {
 		result = append(result, validation.Invalid(path, folderId, errInvalidUUID))
 		return result
+	}
+	return result
+}
+
+func ValidateFormType(formType types.FormType, path *validation.Path) validation.ErrorList {
+	var result validation.ErrorList
+
+	switch formType {
+	case types.DefaultFormType:
+	case types.RecipientFormType:
+	default:
+		result = append(result, validation.NotSupported(path, formType, []string{
+			string(types.DefaultFormType),
+			string(types.RecipientFormType),
+		}))
 	}
 	return result
 }

--- a/pkg/api/types/validation/form_test.go
+++ b/pkg/api/types/validation/form_test.go
@@ -2,13 +2,14 @@ package validation
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
 	"github.com/nrc-no/core/pkg/api/types"
 	"github.com/nrc-no/core/pkg/validation"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"strconv"
-	"strings"
-	"testing"
 )
 
 var textFieldType = types.FieldType{
@@ -35,6 +36,7 @@ var formWithFields = func(fields types.FieldDefinitions) *types.FormDefinition {
 		Name:       validFormName,
 		DatabaseID: validDatabaseID,
 		Fields:     fields,
+		Type:       types.DefaultFormType,
 	}
 }
 
@@ -76,6 +78,7 @@ func TestValidateForm(t *testing.T) {
 				Name:       validFormName,
 				DatabaseID: "",
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name: "form name with surrounding whitespaces",
@@ -86,6 +89,7 @@ func TestValidateForm(t *testing.T) {
 				Name:       " My Form ",
 				DatabaseID: validDatabaseID,
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name: "form name missing",
@@ -96,6 +100,7 @@ func TestValidateForm(t *testing.T) {
 				Name:       "",
 				DatabaseID: validDatabaseID,
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name: "form name too long",
@@ -106,6 +111,7 @@ func TestValidateForm(t *testing.T) {
 				Name:       strings.Repeat("a", formNameMaxLength+1),
 				DatabaseID: validDatabaseID,
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name: "form name too short",
@@ -116,6 +122,7 @@ func TestValidateForm(t *testing.T) {
 				Name:       strings.Repeat("a", formNameMinLength-1),
 				DatabaseID: validDatabaseID,
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name: "bad database id",
@@ -126,6 +133,7 @@ func TestValidateForm(t *testing.T) {
 				Name:       validFormName,
 				DatabaseID: "abc",
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name: "bad folder id",
@@ -137,6 +145,7 @@ func TestValidateForm(t *testing.T) {
 				DatabaseID: validDatabaseID,
 				FolderID:   "abc",
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
 			},
 		}, {
 			name:   "valid folder id",
@@ -146,6 +155,39 @@ func TestValidateForm(t *testing.T) {
 				DatabaseID: validDatabaseID,
 				FolderID:   validFolderID,
 				Fields:     validFields,
+				Type:       types.DefaultFormType,
+			},
+		}, {
+			name:   "default form type",
+			expect: nil,
+			form: &types.FormDefinition{
+				Name:       validFormName,
+				DatabaseID: validDatabaseID,
+				Fields:     validFields,
+				Type:       types.DefaultFormType,
+			},
+		}, {
+			name:   "recipient form type",
+			expect: nil,
+			form: &types.FormDefinition{
+				Name:       validFormName,
+				DatabaseID: validDatabaseID,
+				Fields:     validFields,
+				Type:       types.RecipientFormType,
+			},
+		}, {
+			name: "unknown form type",
+			expect: validation.ErrorList{
+				validation.NotSupported(validation.NewPath("type"), types.FormType("bla"), []string{
+					string(types.DefaultFormType),
+					string(types.RecipientFormType),
+				}),
+			},
+			form: &types.FormDefinition{
+				Name:       validFormName,
+				DatabaseID: validDatabaseID,
+				Fields:     validFields,
+				Type:       "bla",
 			},
 		}, {
 			name: "empty fields",

--- a/pkg/server/formsapi/handlers/form/create.go
+++ b/pkg/server/formsapi/handlers/form/create.go
@@ -1,15 +1,17 @@
 package form
 
 import (
+	"net/http"
+
 	"github.com/emicklei/go-restful/v3"
 	"github.com/nrc-no/core/pkg/api/meta"
 	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/api/types/defaults"
 	"github.com/nrc-no/core/pkg/api/types/validation"
 	"github.com/nrc-no/core/pkg/logging"
 	"github.com/nrc-no/core/pkg/utils"
 	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
-	"net/http"
 )
 
 func (h *Handler) Create() http.HandlerFunc {
@@ -24,6 +26,9 @@ func (h *Handler) Create() http.HandlerFunc {
 			utils.ErrorResponse(w, err)
 			return
 		}
+
+		// apply defaults onto FormDefinition
+		form = defaults.FormDefinitionDefaults(form)
 
 		l.Debug("validating form")
 		if errs := validation.ValidateForm(&form); !errs.IsEmpty() {

--- a/pkg/server/formsapi/tests/form_test.go
+++ b/pkg/server/formsapi/tests/form_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+
 	"github.com/nrc-no/core/pkg/api/types"
 	tu "github.com/nrc-no/core/pkg/testutils"
 	"github.com/stretchr/testify/assert"
@@ -39,8 +40,9 @@ func (s *Suite) TestFormCreateGetList() {
 	}
 
 	tcs := []struct {
-		name   string
-		fields []*types.FieldDefinition
+		name     string
+		formType types.FormType
+		fields   []*types.FieldDefinition
 	}{
 		{
 			name: "With Text Field",
@@ -188,6 +190,12 @@ func (s *Suite) TestFormCreateGetList() {
 					},
 				},
 			},
+		}, {
+			name: "Recipient Form",
+			fields: tu.Fields(
+				tu.ATextField(tu.FieldName("My Field")),
+			),
+			formType: types.RecipientFormType,
 		},
 	}
 
@@ -198,6 +206,7 @@ func (s *Suite) TestFormCreateGetList() {
 			in := &types.FormDefinition{
 				Name:       testCase.name,
 				DatabaseID: db.ID,
+				Type:       testCase.formType,
 				Fields:     testCase.fields,
 			}
 			if err := s.cli.CreateForm(ctx, in, &form); !assert.NoError(s.T(), err) {

--- a/pkg/store/form.go
+++ b/pkg/store/form.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/nrc-no/core/pkg/logging"
 	"github.com/nrc-no/core/pkg/sqlmanager"
 	"github.com/nrc-no/core/pkg/utils/pointers"
 	"golang.org/x/sync/errgroup"
-	"strings"
-	"time"
 
 	"github.com/nrc-no/core/pkg/api/meta"
 	"github.com/nrc-no/core/pkg/api/types"
@@ -86,6 +87,9 @@ type Form struct {
 
 	// Name stores the types.FormDefinition Name
 	Name string
+
+	// Type stores the types.FormDefinition Type
+	Type string
 
 	// CreatedAt represents when this form was created
 	CreatedAt time.Time
@@ -550,6 +554,7 @@ func (f FlatForms) hydrateForm(form *Form) (*types.FormDefinition, error) {
 		DatabaseID: form.DatabaseID,
 		FolderID:   folderId,
 		Name:       form.Name,
+		Type:       types.FormType(form.Type),
 	}
 	fields, err := f.hydrateFormFields(form.ID)
 	if err != nil {
@@ -746,6 +751,7 @@ func flattenForm(form *types.FormDefinition) (FlatForms, error) {
 		OwnerID:     form.ID,
 		FolderID:    folderId,
 		Name:        form.Name,
+		Type:        string(form.Type),
 	}
 	result := FlatForms{
 		Forms: []*Form{flattenedForm},

--- a/pkg/store/form_test.go
+++ b/pkg/store/form_test.go
@@ -1,11 +1,12 @@
 package store
 
 import (
+	"testing"
+
 	"github.com/nrc-no/core/pkg/api/types"
 	"github.com/nrc-no/core/pkg/testutils"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestFlattenHydrateFormDefinition tests that we can flatten and re-hydrate a FormDefinition
@@ -145,6 +146,23 @@ func TestFlattenHydrateFormDefinition(t *testing.T) {
 					testutils.FieldName(fieldName),
 					testutils.FieldID(fieldId)),
 			),
+		}, {
+			name: "with formType",
+			formDefinition: &types.FormDefinition{
+				ID:         "formId",
+				DatabaseID: "databaseId",
+				Name:       "formName",
+				Type:       types.RecipientFormType,
+				Fields: []*types.FieldDefinition{
+					{
+						Name: "textField",
+						ID:   "fieldId",
+						FieldType: types.FieldType{
+							Text: &types.FieldTypeText{},
+						},
+					},
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR adds the "Type" field to the FormDefinition, as well as add logic to store this new field, and validate the value on the `POST /formdefinitions`