### PR TITLE
COR-450 add validation for recipient forms

### DIFF
--- a/pkg/api/types/scheme.go
+++ b/pkg/api/types/scheme.go
@@ -3,10 +3,10 @@ package types
 import "github.com/nrc-no/core/pkg/api/meta"
 
 const group = "core.nrc.no"
-const version = "v1"
 const folders = "folders"
 const databases = "databases"
 const records = "records"
+const forms = "forms"
 
 var FolderGR = meta.GroupResource{
 	Group:    group,
@@ -21,4 +21,9 @@ var DatabaseGR = meta.GroupResource{
 var RecordGR = meta.GroupResource{
 	Group:    group,
 	Resource: records,
+}
+
+var FormGR = meta.GroupResource{
+	Group:    group,
+	Resource: forms,
 }

--- a/pkg/api/types/validation/form.go
+++ b/pkg/api/types/validation/form.go
@@ -65,6 +65,7 @@ func ValidateForm(form *types.FormDefinition) validation.ErrorList {
 	result = append(result, ValidateFormFolderID(form.FolderID, validation.NewPath("folderId"))...)
 	result = append(result, ValidateFormType(form.Type, validation.NewPath("type"))...)
 	result = append(result, ValidateFormFields(form.Fields, validation.NewPath("fields"))...)
+	result = append(result, ValidateRecipientForm(form)...)
 	return result
 }
 

--- a/pkg/api/types/validation/recipient.go
+++ b/pkg/api/types/validation/recipient.go
@@ -1,0 +1,74 @@
+package validation
+
+import (
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/validation"
+)
+
+const (
+	errRecipientMultipleKeyFields         = "Recipient forms can have at most one key field"
+	errRecipientMustHaveReferenceKeyField = "The key field for recipient forms must be a Reference field"
+)
+
+// ValidateRecipientForm validates recipient forms
+func ValidateRecipientForm(form *types.FormDefinition) validation.ErrorList {
+	var result validation.ErrorList
+	if form.Type != types.RecipientFormType {
+		return result
+	}
+
+	fieldsPath := validation.NewPath("fields")
+
+	keyField, keyFieldIndex, singleKeyFieldErrs := validateRecipientFormHasSingleKeyField(form.Fields, fieldsPath)
+	result = append(result, singleKeyFieldErrs...)
+
+	if keyField != nil {
+		keyFieldRefErrs := validateRecipientKeyFieldIsReference(keyField, fieldsPath.Index(keyFieldIndex))
+		result = append(result, keyFieldRefErrs...)
+	}
+
+	return result
+}
+
+func validateRecipientKeyFieldIsReference(
+	keyField *types.FieldDefinition,
+	path *validation.Path,
+) validation.ErrorList {
+	var result validation.ErrorList
+
+	keyFieldKind, err := keyField.FieldType.GetFieldKind()
+	if err != nil {
+		result = append(result, validation.InternalError(path, err))
+		return result
+	}
+
+	if keyFieldKind != types.FieldKindReference {
+		result = append(result, validation.Invalid(path.Child("fieldType"), keyFieldKind, errRecipientMustHaveReferenceKeyField))
+		return result
+	}
+
+	return result
+}
+
+// validateRecipientFormHasSingleKeyField validates that a recipient form has at most a single key field
+func validateRecipientFormHasSingleKeyField(
+	fields types.FieldDefinitions,
+	path *validation.Path,
+) (*types.FieldDefinition, int, validation.ErrorList) {
+	var result validation.ErrorList
+	var keyField *types.FieldDefinition
+	var keyFieldIndex = -1
+	for i, field := range fields {
+		keyPath := path.Index(i).Child("key")
+		if !field.Key {
+			continue
+		}
+		if keyField != nil {
+			result = append(result, validation.Invalid(keyPath, field.Key, errRecipientMultipleKeyFields))
+			return nil, -1, result
+		}
+		keyFieldIndex = i
+		keyField = field
+	}
+	return keyField, keyFieldIndex, result
+}

--- a/pkg/api/types/validation/recipient_test.go
+++ b/pkg/api/types/validation/recipient_test.go
@@ -3,10 +3,48 @@ package validation
 import (
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
+
 	"github.com/nrc-no/core/pkg/api/types"
 	"github.com/nrc-no/core/pkg/validation"
 	"github.com/stretchr/testify/assert"
 )
+
+func Test_ValidateRecipientForm_SkippedWhenNotRecipientForm(t *testing.T) {
+
+	validFormButInvalidRecipientForm := &types.FormDefinition{
+		Type:       types.DefaultFormType,
+		Name:       "test",
+		DatabaseID: uuid.NewV4().String(),
+		Fields: []*types.FieldDefinition{
+			{
+				Key:      true,
+				Name:     "bla",
+				Required: true,
+				FieldType: types.FieldType{
+					Text: &types.FieldTypeText{},
+				},
+			},
+			{
+				Key:      true,
+				Required: true,
+				Name:     "bli",
+				FieldType: types.FieldType{
+					Text: &types.FieldTypeText{},
+				},
+			},
+		},
+	}
+
+	// assert that the form is valid
+	assert.Equal(t, validation.ErrorList(nil), ValidateForm(validFormButInvalidRecipientForm))
+
+	// change the type to "Recipient"
+	validFormButInvalidRecipientForm.Type = types.RecipientFormType
+
+	// assert that the form is now invalid
+	assert.False(t, ValidateForm(validFormButInvalidRecipientForm).IsEmpty())
+}
 
 func Test_validateRecipientFormHasSingleKeyField(t *testing.T) {
 	tests := []struct {

--- a/pkg/api/types/validation/recipient_test.go
+++ b/pkg/api/types/validation/recipient_test.go
@@ -1,0 +1,84 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/nrc-no/core/pkg/api/types"
+	"github.com/nrc-no/core/pkg/validation"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateRecipientFormHasSingleKeyField(t *testing.T) {
+	tests := []struct {
+		name           string
+		fields         types.FieldDefinitions
+		path           *validation.Path
+		wantField      *types.FieldDefinition
+		wantFieldIndex int
+		wantErrs       validation.ErrorList
+	}{
+		{
+			name:           "without key field",
+			fields:         []*types.FieldDefinition{},
+			path:           validation.NewPath("fields"),
+			wantField:      nil,
+			wantFieldIndex: -1,
+			wantErrs:       nil,
+		},
+		{
+			name: "with single key field",
+			fields: []*types.FieldDefinition{
+				{
+					Key: true,
+					FieldType: types.FieldType{
+						Text: &types.FieldTypeText{},
+					},
+				},
+			},
+			path: validation.NewPath("fields"),
+			wantField: &types.FieldDefinition{
+				Key: true,
+				FieldType: types.FieldType{
+					Text: &types.FieldTypeText{},
+				},
+			},
+			wantFieldIndex: 0,
+			wantErrs:       nil,
+		},
+		{
+			name: "with multiple key field",
+			fields: []*types.FieldDefinition{
+				{
+					Key: true,
+					FieldType: types.FieldType{
+						Text: &types.FieldTypeText{},
+					},
+				},
+				{
+					Key: true,
+					FieldType: types.FieldType{
+						Text: &types.FieldTypeText{},
+					},
+				},
+			},
+			path:           validation.NewPath("fields"),
+			wantField:      nil,
+			wantFieldIndex: -1,
+			wantErrs: validation.ErrorList{
+				validation.Invalid(
+					validation.NewPath("fields").Index(1).Child("key"),
+					true,
+					errRecipientMultipleKeyFields,
+				),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2 := validateRecipientFormHasSingleKeyField(tt.fields, tt.path)
+			assert.Equalf(t, tt.wantField, got, "validateRecipientFormHasSingleKeyField(%v, %v)", tt.fields, tt.path)
+			assert.Equalf(t, tt.wantFieldIndex, got1, "validateRecipientFormHasSingleKeyField(%v, %v)", tt.fields, tt.path)
+			assert.Equalf(t, tt.wantErrs, got2, "validateRecipientFormHasSingleKeyField(%v, %v)", tt.fields, tt.path)
+		})
+	}
+}

--- a/pkg/server/formsapi/handlers/form/create_test.go
+++ b/pkg/server/formsapi/handlers/form/create_test.go
@@ -1,0 +1,76 @@
+package form
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nrc-no/core/pkg/api/types"
+)
+
+func Test_validateRecipientFormParent(t *testing.T) {
+
+	aNonRecipientForm := types.FormDefinition{
+		Type: types.DefaultFormType,
+	}
+
+	aRecipientFormWithoutParent := types.FormDefinition{
+		Type: types.RecipientFormType,
+	}
+
+	aRecipientFormWithParent := types.FormDefinition{
+		Type: types.RecipientFormType,
+		Fields: []*types.FieldDefinition{
+			{
+				Key: true,
+				FieldType: types.FieldType{
+					Reference: &types.FieldTypeReference{},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		form    types.FormDefinition
+		getForm func(ctx context.Context, formID string) (*types.FormDefinition, error)
+		wantErr bool
+	}{
+		{
+			name:    "not a recipient form",
+			ctx:     context.Background(),
+			form:    aNonRecipientForm,
+			getForm: nil,
+			wantErr: false,
+		}, {
+			name:    "no parent",
+			ctx:     context.Background(),
+			form:    aRecipientFormWithoutParent,
+			getForm: nil,
+			wantErr: false,
+		}, {
+			name: "with recipient parent",
+			ctx:  context.Background(),
+			form: aRecipientFormWithParent,
+			getForm: func(ctx context.Context, formID string) (*types.FormDefinition, error) {
+				return &types.FormDefinition{Type: types.RecipientFormType}, nil
+			},
+			wantErr: false,
+		}, {
+			name: "with non-recipient parent",
+			ctx:  context.Background(),
+			form: aRecipientFormWithParent,
+			getForm: func(ctx context.Context, formID string) (*types.FormDefinition, error) {
+				return &types.FormDefinition{Type: types.DefaultFormType}, nil
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateRecipientFormParent(tt.ctx, tt.form, tt.getForm); (err != nil) != tt.wantErr {
+				t.Errorf("validateRecipientFormParent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added validation for "Recipient" forms

The validation happens in two parts
1. The static validation, things we can infer without having to make any database calls. That lies in the default "validation" package, where all other validation currently lies.
2. The dynamic validation, that happens for now in the POST /formdefinitions handler. Here, we must make a DB call to check if the "parent" of a recipient form is also a recipient form.

This PR is based off COR-499 branch, so I set the PR target to the COR-499 branch until the other one gets merged into main