### PR TITLE
Cor 492 read subrecord values backend

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,8 @@
 approvers:
   - ludydoo
   - internetti
-  - shinroo
-  - senyaoh
-  - nilueps
   - neb42
 reviewers:
   - ludydoo
   - internetti
-  - shinroo
-  - senyaoh
-  - nilueps
   - neb42

--- a/frontend/packages/core-api-client/src/client/Record.ts
+++ b/frontend/packages/core-api-client/src/client/Record.ts
@@ -1,7 +1,5 @@
-import { getFieldKind } from '..';
 import {
   Record,
-  FieldKind,
   RecordCreateRequest,
   RecordCreateResponse,
   RecordGetRequest,
@@ -28,98 +26,27 @@ export class RecordClient {
     return this.restClient.do(request, '/records', 'post', request.object, 200);
   };
 
-  list = async (request: RecordListRequest): Promise<RecordListResponse> => {
+  list = (request: RecordListRequest): Promise<RecordListResponse> => {
     const { databaseId, formId } = request;
     const url = `/records?databaseId=${databaseId}&formId=${formId}`;
-    const response = await this.restClient.do<RecordListRequest, RecordList>(
+    return this.restClient.do<RecordListRequest, RecordList>(
       request,
       url,
       'get',
       undefined,
       200,
     );
-
-    if (!response.response) return response;
-
-    const recordList = await Promise.all(
-      response.response.items.map(async (record) => this.massageRecord(record)),
-    );
-
-    return {
-      ...response,
-      response: {
-        ...response.response,
-        items: recordList,
-      },
-    };
   };
 
-  get = async (request: RecordGetRequest): Promise<RecordGetResponse> => {
+  get = (request: RecordGetRequest): Promise<RecordGetResponse> => {
     const { databaseId, formId, recordId } = request;
     const url = `/records/${recordId}?databaseId=${databaseId}&formId=${formId}`;
-    const response = await this.restClient.do<RecordGetRequest, Record>(
+    return this.restClient.do<RecordGetRequest, Record>(
       request,
       url,
       'get',
       undefined,
       200,
     );
-
-    if (!response.response) return response;
-
-    const record = await this.massageRecord(response.response);
-
-    return {
-      ...response,
-      response: record,
-    };
-  };
-
-  /**
-   * Takes a record and populates it with additional information
-   * Fetches subrecord values and adds them to the record's values
-   * TODO: Change boolean values from string to booleans
-   * TODO: Fetch reference field values to have a human readable name
-   */
-  private massageRecord = async (record: Record): Promise<Record> => {
-    // Fetching a subrecords form returns the owner form causing an infinite loop so we skip over subrecords
-    if (record.ownerId) return record;
-
-    // Fetch the record's form to get a complete list of fields
-    const formResponse = await this.formClient.get({ id: record.formId });
-
-    if (!formResponse.response) return record;
-
-    // Iterate over the forms fields
-    // if it's a subform field, fetch the subform records and populate with their values
-    // otherwise, just add the field value to the record
-    const values = await Promise.all(
-      formResponse.response?.fields.map(async (field) => {
-        if (getFieldKind(field.fieldType) === FieldKind.SubForm) {
-          const subrecordList = await this.list({
-            databaseId: record.databaseId,
-            formId: field.id,
-          });
-          return {
-            fieldId: field.id,
-            value:
-              subrecordList.response?.items.map(
-                (subrecord) => subrecord.values,
-              ) ?? [],
-          };
-        }
-
-        const existingValue = record.values.find(
-          (value) => value.fieldId === field.id,
-        );
-        if (!existingValue) throw new Error(); // Should never happen, unless form and record don't match
-        return existingValue;
-      }) ?? [],
-    );
-
-    return {
-      ...record,
-      values,
-    };
   };
 }

--- a/pkg/api/types/record_test.go
+++ b/pkg/api/types/record_test.go
@@ -2,8 +2,9 @@ package types
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestStringOrArrayMarshaling tests that we can successfully Marshal and Unmarshal
@@ -23,30 +24,54 @@ func TestStringOrArrayMarshaling(t *testing.T) {
 				Kind:       ArrayValue,
 				ArrayValue: []string{"val1", "val2"},
 			},
-		}, {
+		},
+		{
 			name: "string",
 			json: `"val1"`,
 			val: StringOrArray{
 				Kind:        StringValue,
 				StringValue: "val1",
 			},
-		}, {
+		},
+		{
+			name: "subform",
+			json: `[[{"fieldId":"1","value":"val1"},{"fieldId":"2","value":["val2","val3"]}],[{"fieldId":"1","value":"val4"},{"fieldId":"2","value":["val5","val6"]}]]`,
+			val: NewSubFormValue([]FieldValues{
+				FieldValues{
+					NewFieldStringValue("1", "val1"),
+					NewFieldArrayValue("2", []string{"val2", "val3"}),
+				},
+				FieldValues{
+					NewFieldStringValue("1", "val4"),
+					NewFieldArrayValue("2", []string{"val5", "val6"}),
+				},
+			}),
+		},
+		{
 			name: "null string",
 			json: `null`,
 			val: StringOrArray{
 				Kind: NullValue,
 			},
-		}, {
+		},
+		{
 			name:      "bad value",
 			json:      `123`,
 			expectErr: true,
-		}, {
+		},
+		{
 			name:      "bad string",
 			json:      `"ab`,
 			expectErr: true,
-		}, {
+		},
+		{
 			name:      "bad slice",
 			json:      `["a","b"`,
+			expectErr: true,
+		},
+		{
+			name:      "bad nested slice",
+			json:      `[[{"fieldId":"1","value":"val1"}]`,
 			expectErr: true,
 		},
 	}

--- a/pkg/sqlmanager/reader.go
+++ b/pkg/sqlmanager/reader.go
@@ -71,7 +71,7 @@ func queryRecords(ctx context.Context, db *gorm.DB, form types.FormInterface, sq
 		return nil, err
 	}
 
-	subRecords, err := querySubRecords(ctx, db, form, args)
+	subRecords, err := querySubRecords(ctx, db, form, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,11 +102,11 @@ func querySubRecords(ctx context.Context, db *gorm.DB, form types.FormInterface,
 			}
 
 			query := ""
-			if len(args) > 0 {
+			if len(args) > 0 && args[0] != nil {
 				query = fmt.Sprintf("where %s = ?", keyOwnerIdColumn)
 			}
 
-			subFormRecordList, err := queryRecords(ctx, db, subForm, query, args)
+			subFormRecordList, err := queryRecords(ctx, db, subForm, query, args...)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sqlmanager/reader.go
+++ b/pkg/sqlmanager/reader.go
@@ -373,6 +373,12 @@ func readInBooleanField(record *types.Record, field *types.FieldDefinition, valu
 }
 
 func readInSubFormField(record *types.Record, subRecords *types.RecordList, field *types.FieldDefinition) error {
+	// When we create a record we don't create the sub records and the resulting GET will fail while getting the subrecords
+	// We should create both together, but for now we just create the record and ignore the subrecords
+	if subRecords == nil {
+		return nil
+	}
+
 	value := make([]types.FieldValues, 0)
 
 	for _, subRecord := range subRecords.Items {

--- a/pkg/sqlmanager/reader_test.go
+++ b/pkg/sqlmanager/reader_test.go
@@ -239,7 +239,7 @@ func TestReader(t *testing.T) {
 			mockSql := newMockSQLReader(tt.columns, tt.values)
 			mockSql.columnsThrows = tt.columnsThrows
 			mockSql.scanThrows = tt.scanThrows
-			got, err := readRecords(tt.form, mockSql)
+			got, err := readRecords(tt.form, mockSql, map[string]map[string]*types.RecordList{})
 			if tt.wantErr {
 				assert.Error(t, err)
 				return


### PR DESCRIPTION
* Extend `FieldValue.Value` to accept `[][]FieldValue`
* When reading records, also read sub records and populate the response

TODO:
* Tests
* Rename `StringOrArray`

Future work:
* Take a similar approach to writing records. I think we currently have to make a POST request for every subrecord we create rather than a single payload.